### PR TITLE
修复bug

### DIFF
--- a/D1_SETUP_GUIDE.md
+++ b/D1_SETUP_GUIDE.md
@@ -12,17 +12,17 @@
 
 ```bash
 # 创建 D1 数据库
-wrangler d1 create misub-database
+wrangler d1 create misub
 ```
 
 命令执行后，您会看到类似以下的输出：
 ```
-✅ Successfully created DB 'misub-database' in region APAC
+✅ Successfully created DB 'misub' in region APAC
 Created your database using D1's new storage backend. The new storage backend is not yet recommended for production workloads, but backs up your data via point-in-time restore.
 
 [[d1_databases]]
 binding = "MISUB_DB"
-database_name = "misub-database"
+database_name = "misub"
 database_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 ```
 
@@ -33,7 +33,7 @@ database_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 ```toml
 [[d1_databases]]
 binding = "MISUB_DB"
-database_name = "misub-database"
+database_name = "misub"
 database_id = "your-actual-database-id-here"  # 替换为实际的数据库 ID
 preview_database_id = "your-actual-database-id-here"  # 同样替换为实际的数据库 ID
 ```
@@ -133,7 +133,7 @@ A: 这通常是因为 KV 写入限制或存储类型配置问题：
 wrangler d1 list
 
 # 查询数据库表
-wrangler d1 execute misub-database --command="SELECT name FROM sqlite_master WHERE type='table';"
+wrangler d1 execute misub --command="SELECT name FROM sqlite_master WHERE type='table';"
 ```
 
 ## 📞 支持

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ MiSub 不仅仅是一个简单的订阅转换工具，它经过了深度的架�
 
 **创建 D1 数据库：**
 ```bash
-wrangler d1 create misub-database
+wrangler d1 create misub
 ```
 
 **在项目设定中绑定 D1 数据库：**
@@ -123,7 +123,7 @@ wrangler d1 create misub-database
 
 **初始化数据库表结构：**
 ```bash
-wrangler d1 execute misub-database --file=schema.sql --remote
+wrangler d1 execute misub --file=schema.sql --remote
 ```
 
 > 💡 **提示**: D1 数据库是可选的，如果不配置，系统会默认使用 KV 存储。配置后可在设置中选择存储类型。（若无法初始化数据库请前往控制台手动执行schema.sql）

--- a/README.md
+++ b/README.md
@@ -123,10 +123,10 @@ wrangler d1 create misub-database
 
 **初始化数据库表结构：**
 ```bash
-wrangler d1 execute misub-database --file=schema.sql
+wrangler d1 execute misub-database --file=schema.sql --remote
 ```
 
-> 💡 **提示**: D1 数据库是可选的，如果不配置，系统会默认使用 KV 存储。配置后可在设置中选择存储类型。
+> 💡 **提示**: D1 数据库是可选的，如果不配置，系统会默认使用 KV 存储。配置后可在设置中选择存储类型。（若无法初始化数据库请前往控制台手动执行schema.sql）
 
 #### 4. 设定环境变数
 

--- a/functions/storage-adapter.js
+++ b/functions/storage-adapter.js
@@ -228,20 +228,7 @@ export class StorageFactory {
      */
     static async getStorageType(env) {
         try {
-            // 先尝试从 KV 读取设置
-            let settings = null;
-            try {
-                settings = await env.MISUB_KV.get(DATA_KEYS.SETTINGS, 'json');
-            } catch (kvError) {
-                console.warn('[Storage] Failed to read from KV:', kvError.message);
-            }
-
-            // 如果 KV 中有设置且指定了存储类型，使用它
-            if (settings?.storageType) {
-                return settings.storageType;
-            }
-
-            // 如果 KV 中没有设置或没有存储类型，尝试从 D1 读取
+            // 优先从 D1 读取设置（若已切换到 D1，则后续请求不会触碰 KV）
             if (env.MISUB_DB) {
                 try {
                     const d1Adapter = new D1StorageAdapter(env.MISUB_DB);
@@ -252,6 +239,17 @@ export class StorageFactory {
                 } catch (d1Error) {
                     console.warn('[Storage] Failed to read from D1:', d1Error.message);
                 }
+            }
+
+            // 回退：从 KV 读取设置（默认仍支持 KV）
+            let settings = null;
+            try {
+                settings = await env.MISUB_KV.get(DATA_KEYS.SETTINGS, 'json');
+            } catch (kvError) {
+                console.warn('[Storage] Failed to read from KV:', kvError.message);
+            }
+            if (settings?.storageType) {
+                return settings.storageType;
             }
 
             // 默认使用 KV

--- a/schema.sql
+++ b/schema.sql
@@ -1,8 +1,4 @@
--- MiSub D1 数据库表结构
--- 用于替代 KV 存储，解决写入限制问题
 
--- 订阅数据表
--- 存储所有订阅源的数据
 CREATE TABLE IF NOT EXISTS subscriptions (
     id TEXT PRIMARY KEY,
     data TEXT NOT NULL,
@@ -10,8 +6,7 @@ CREATE TABLE IF NOT EXISTS subscriptions (
     updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
 );
 
--- 配置文件表
--- 存储订阅组配置
+
 CREATE TABLE IF NOT EXISTS profiles (
     id TEXT PRIMARY KEY,
     data TEXT NOT NULL,
@@ -19,8 +14,7 @@ CREATE TABLE IF NOT EXISTS profiles (
     updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
 );
 
--- 系统设置表
--- 存储系统配置信息，使用 key-value 结构
+
 CREATE TABLE IF NOT EXISTS settings (
     key TEXT PRIMARY KEY,
     value TEXT NOT NULL,
@@ -28,7 +22,6 @@ CREATE TABLE IF NOT EXISTS settings (
     updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
 );
 
--- 创建索引以提高查询性能
 CREATE INDEX IF NOT EXISTS idx_subscriptions_updated_at ON subscriptions(updated_at);
 CREATE INDEX IF NOT EXISTS idx_profiles_updated_at ON profiles(updated_at);
 CREATE INDEX IF NOT EXISTS idx_settings_updated_at ON settings(updated_at);


### PR DESCRIPTION
🛠️ 已修复的内容

  1. README.md 修复

  - ✅ 统一数据库创建命令：wrangler d1 create misub
  - ✅ 统一数据库执行命令：wrangler d1 execute misub --file=schema.sql --remote

  2. D1_SETUP_GUIDE.md 修复

  - ✅ 统一数据库创建命令：wrangler d1 create misub
  - ✅ 更新示例输出中的数据库名称
  - ✅ 统一配置示例中的 database_name = "misub"
  - ✅ 修复验证命令：wrangler d1 execute misub --command="..."
  
  3.修复切换到D1后还会使用kv读的bug

  ✅ 修复后的正确流程

  现在用户应该按照以下步骤操作：

  # 1. 创建数据库
  wrangler d1 create misub

  # 2. 初始化表结构
  wrangler d1 execute misub --file=schema.sql --remote