### PR TITLE
Improve protocol parsing robustness and Quantumult X coverage

### DIFF
--- a/functions/modules/utils/node-parser.js
+++ b/functions/modules/utils/node-parser.js
@@ -609,6 +609,19 @@ export function validateSnellNode(url) {
             return { valid: false, error: '不是 Snell 协议 URL' };
         }
 
+        // 提前验证端口，避免 URL 解析在端口范围错误时直接抛出
+        const portMatch = url.match(/:(\d+)(?:[/?#]|$)/);
+        if (portMatch) {
+            const portNumber = parseInt(portMatch[1]);
+            if (portNumber < 1 || portNumber > 65535) {
+                return {
+                    valid: false,
+                    error: `端口号无效: ${portNumber} (范围: 1-65535)`,
+                    details: { port: portNumber }
+                };
+            }
+        }
+
         const proxy = parseSnellUrl(url);
         if (!proxy) {
             return { valid: false, error: '无效的 Snell URL 格式' };

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -98,8 +98,10 @@ export function prependNodeName(link, prefix) {
 
 /**
  * [新增] 从节点链接中提取主机和端口
+ * 支持 VMess 的 JSON Base64、SS/SSR 的编码片段等特殊格式，
+ * 如果无法解析会返回包含回退文本的对象。
  * @param {string} url - 节点链接
- * @returns {{host: string, port: string}}
+ * @returns {{host: string, port: string}} - 解析失败时返回 { host: '解析失败', port: 'N/A' }
  */
 export function extractHostAndPort(url) {
     if (!url) return { host: '', port: '' };

--- a/src/utils/protocolConverter.js
+++ b/src/utils/protocolConverter.js
@@ -87,7 +87,7 @@ function convertShadowsocksToUrl(proxy) {
 /**
  * ShadowsocksR配置转换为URL
  */
-function convertShadowsockRToUrl(proxy) {
+function convertShadowsocksRToUrl(proxy) {
     try {
         if (!proxy.server || !proxy.port || !proxy.password) {
             return null;
@@ -338,7 +338,7 @@ export function convertClashProxyToUrl(proxy) {
             return convertShadowsocksToUrl(proxy);
         case 'ssr':
         case 'shadowsocksr':
-            return convertShadowsockRToUrl(proxy);
+            return convertShadowsocksRToUrl(proxy);
         case 'trojan':
             return convertTrojanToUrl(proxy);
         case 'vless':
@@ -478,27 +478,37 @@ export function parseSurgeConfig(content) {
 
     for (let i = 0; i < lines.length; i++) {
         const line = lines[i].trim();
+        const lowerLine = line.toLowerCase();
+        const equalIndex = line.indexOf('=');
+        const valuePrefix = equalIndex !== -1
+            ? line.slice(equalIndex + 1).split(',')[0].trim().toLowerCase()
+            : '';
 
         // 匹配代理规则
-        if (line.toLowerCase().startsWith('[proxy]') || line.toLowerCase().startsWith('[proxies]')) {
+        if (lowerLine.startsWith('[proxy]') || lowerLine.startsWith('[proxies]')) {
             // Surge代理配置
             continue;
         }
 
         // 解析不同类型的代理
-        if (line.toLowerCase().startsWith('vmess')) {
+        if (lowerLine.startsWith('vmess') || valuePrefix === 'vmess') {
             const node = parseSurgeVmess(line);
             if (node) nodes.push(node);
-        } else if (line.toLowerCase().startsWith('ss')) {
+        } else if (lowerLine.startsWith('ss') || valuePrefix === 'ss') {
             const node = parseSurgeSS(line);
             if (node) nodes.push(node);
-        } else if (line.toLowerCase().startsWith('trojan')) {
+        } else if (lowerLine.startsWith('trojan') || valuePrefix === 'trojan') {
             const node = parseSurgeTrojan(line);
             if (node) nodes.push(node);
-        } else if (line.toLowerCase().startsWith('http-proxy') || line.toLowerCase().startsWith('https-proxy')) {
+        } else if (
+            lowerLine.startsWith('http-proxy') ||
+            lowerLine.startsWith('https-proxy') ||
+            valuePrefix === 'http-proxy' ||
+            valuePrefix === 'https-proxy'
+        ) {
             const node = parseSurgeHTTP(line);
             if (node) nodes.push(node);
-        } else if (line.toLowerCase().startsWith('snell')) {
+        } else if (lowerLine.startsWith('snell') || valuePrefix === 'snell') {
             const node = parseSurgeSnell(line);
             if (node) nodes.push(node);
         }
@@ -708,12 +718,12 @@ export function parseQuantumultXConfig(content) {
 /**
  * 解析Quantumult X VMess配置
  */
-function parseQuantumletXVmess(line) {
+function parseQuantumultXVmess(line) {
     try {
-        const parts = line.split('=');
-        if (parts.length < 2) return null;
+        const equalIndex = line.indexOf('=');
+        if (equalIndex === -1) return null;
 
-        const config = parts[1];
+        const config = line.slice(equalIndex + 1);
         const params = config.split(',').map(p => p.trim());
 
         if (params.length < 6) return null;
@@ -772,10 +782,10 @@ function parseQuantumletXVmess(line) {
  */
 function parseQuantumultXSS(line) {
     try {
-        const parts = line.split('=');
-        if (parts.length < 2) return null;
+        const equalIndex = line.indexOf('=');
+        if (equalIndex === -1) return null;
 
-        const config = parts[1];
+        const config = line.slice(equalIndex + 1);
         const params = config.split(',').map(p => p.trim());
 
         if (params.length < 5) return null;
@@ -804,10 +814,10 @@ function parseQuantumultXSS(line) {
  */
 function parseQuantumultXTrojan(line) {
     try {
-        const parts = line.split('=');
-        if (parts.length < 2) return null;
+        const equalIndex = line.indexOf('=');
+        if (equalIndex === -1) return null;
 
-        const config = parts[1];
+        const config = line.slice(equalIndex + 1);
         const params = config.split(',').map(p => p.trim());
 
         if (params.length < 4) return null;
@@ -834,10 +844,10 @@ function parseQuantumultXTrojan(line) {
  */
 function parseQuantumultXHTTP(line) {
     try {
-        const parts = line.split('=');
-        if (parts.length < 2) return null;
+        const equalIndex = line.indexOf('=');
+        if (equalIndex === -1) return null;
 
-        const config = parts[1];
+        const config = line.slice(equalIndex + 1);
         const params = config.split(',').map(p => p.trim());
 
         if (params.length < 3) return null;

--- a/tests/unit/protocolConverter.test.js
+++ b/tests/unit/protocolConverter.test.js
@@ -212,5 +212,23 @@ ss=Test SS,1.2.3.4,8388,aes-256-gcm,password123
             const result = parseQuantumultXConfig('')
             expect(result).toEqual([])
         })
+
+        it('应解析VMess配置并生成有效URL', () => {
+            const config = `
+[server_local]
+vmess=Test VMess, vmess.example.com, 443, auto, uuid-1234, 0, net=ws, host=example.com, path=/ws
+`
+            const result = parseQuantumultXConfig(config)
+
+            expect(result).toHaveLength(1)
+            const node = result[0]
+            expect(node.protocol).toBe('vmess')
+
+            const decoded = JSON.parse(atob(node.url.replace('vmess://', '')))
+            expect(decoded.add).toBe('vmess.example.com')
+            expect(decoded.net).toBe('ws')
+            expect(decoded.path).toBe('/ws')
+            expect(decoded.host).toBe('example.com')
+        })
     })
 })


### PR DESCRIPTION
## Summary
- make Surge and Quantumult X parsing more resilient, including fixing the ShadowsocksR helper name
- add clearer host/port extraction documentation and early Snell port validation
- extend Quantumult X VMess parsing tests to cover WebSocket parameters

## Testing
- npm run test:run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952859c1938832ab6bbb64522f2d500)