### PR TITLE
Normalize subconverter URLs to prevent subscription 502 errors

### DIFF
--- a/functions/modules/subscription-handler.js
+++ b/functions/modules/subscription-handler.js
@@ -19,6 +19,38 @@ import {
 } from '../services/node-cache-service.js';
 
 /**
+ * 构建 SubConverter 请求的基础 URL，兼容带/不带协议的配置
+ * @param {string} backend - 用户配置的 SubConverter 地址
+ * @returns {URL} - 规范化后的 URL 对象，指向 /sub 路径
+ */
+function buildSubconverterUrl(backend) {
+    if (!backend || backend.trim() === '') {
+        throw new Error('Subconverter backend is not configured.');
+    }
+
+    const trimmed = backend.trim();
+    const hasProtocol = /^https?:\/\//i.test(trimmed);
+
+    let baseUrl;
+    try {
+        baseUrl = new URL(hasProtocol ? trimmed : `https://${trimmed}`);
+    } catch (err) {
+        throw new Error(`Invalid Subconverter backend: ${trimmed}`);
+    }
+
+    const normalizedPath = baseUrl.pathname.replace(/\/+$/, '');
+    if (!normalizedPath || normalizedPath === '') {
+        baseUrl.pathname = '/sub';
+    } else if (!/\/sub$/i.test(normalizedPath)) {
+        baseUrl.pathname = `${normalizedPath}/sub`;
+    } else {
+        baseUrl.pathname = normalizedPath;
+    }
+
+    return baseUrl;
+}
+
+/**
  * 处理MiSub订阅请求
  * @param {Object} context - Cloudflare上下文
  * @returns {Promise<Response>} HTTP响应
@@ -478,7 +510,7 @@ export async function handleMisubRequest(context) {
         return new Response(base64Content, { headers });
     }
 
-    const subconverterUrl = new URL(`https://${effectiveSubConverter}/sub`);
+    const subconverterUrl = buildSubconverterUrl(effectiveSubConverter);
     subconverterUrl.searchParams.set('target', targetFormat);
     subconverterUrl.searchParams.set('url', callbackUrl);
     subconverterUrl.searchParams.set('scv', 'true');


### PR DESCRIPTION
## Summary
- add normalization for SubConverter backend values to handle inputs that include protocols or paths
- apply the normalized URL when requesting conversions so profile subscriptions no longer fail with invalid backend formats

## Testing
- npm run test:run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695606437154832aac64b154c966de8a)