### PR TITLE
调整 CSP：允许 Google Fonts 与 Cloudflare Insights 资源加载

### DIFF
--- a/functions/middleware/cors.js
+++ b/functions/middleware/cors.js
@@ -86,7 +86,7 @@ export async function securityHeadersMiddleware(request, next) {
     response.headers.set('Permissions-Policy', 'camera=(), microphone=(), geolocation=()');
     response.headers.set(
         'Content-Security-Policy',
-        "default-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; img-src 'self' data: blob:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; connect-src 'self' https: http:; worker-src 'self' blob:;"
+        "default-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; img-src 'self' data: blob:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https: http:; worker-src 'self' blob:;"
     );
 
     return response;


### PR DESCRIPTION
### Motivation
- 修复登录后浏览器控制台报错并导致页面除导航栏外内容为空白的问题，排查为严格的 `Content-Security-Policy` 拦截了字体与分析脚本资源。

### Description
- 在 `functions/middleware/cors.js` 中放宽 `Content-Security-Policy`，在 `script-src` 中允许 `https://static.cloudflareinsights.com`，在 `style-src` 中允许 `https://fonts.googleapis.com`，并新增 `font-src` 允许 `https://fonts.gstatic.com` 与 `data:`，以避免字体和分析脚本被 CSP 拦截。
