### PR TITLE
登录后强制刷新以避免首屏渲染空白，并放宽 CSP 允许 Google Fonts 与 Cloudflare Insights

### DIFF
--- a/functions/middleware/cors.js
+++ b/functions/middleware/cors.js
@@ -86,7 +86,7 @@ export async function securityHeadersMiddleware(request, next) {
     response.headers.set('Permissions-Policy', 'camera=(), microphone=(), geolocation=()');
     response.headers.set(
         'Content-Security-Policy',
-        "default-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; img-src 'self' data: blob:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; connect-src 'self' https: http:; worker-src 'self' blob:;"
+        "default-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; img-src 'self' data: blob:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https: http:; worker-src 'self' blob:;"
     );
 
     return response;

--- a/src/stores/session.js
+++ b/src/stores/session.js
@@ -11,6 +11,15 @@ export const useSessionStore = defineStore('session', () => {
   const initialData = ref(null);
   const publicConfig = ref({ enablePublicPage: true }); // Default true until fetched
   const isConfigReady = ref(false);
+  const loginReloadKey = 'misub:post-login-reload';
+
+  const canUseSessionStorage = () => {
+    try {
+      return typeof window !== 'undefined' && typeof window.sessionStorage !== 'undefined';
+    } catch (error) {
+      return false;
+    }
+  };
 
   async function checkSession() {
     try {
@@ -62,6 +71,15 @@ export const useSessionStore = defineStore('session', () => {
       const success = await handleLoginSuccess();
       if (success) {
         // 登录成功后跳转到首页 (HomeView will show Dashboard)
+        // 避免首次登录时路由切换导致的渲染异常，执行一次强制刷新
+        if (canUseSessionStorage()) {
+          const hasReloaded = window.sessionStorage.getItem(loginReloadKey) === '1';
+          if (!hasReloaded) {
+            window.sessionStorage.setItem(loginReloadKey, '1');
+            window.location.replace('/');
+            return;
+          }
+        }
         await router.push({ path: '/' });
       } else {
         throw new Error('登录后校验失败，请稍后重试');
@@ -88,6 +106,9 @@ export const useSessionStore = defineStore('session', () => {
     // 清除缓存数据
     const dataStore = useDataStore();
     dataStore.clearCachedData();
+    if (canUseSessionStorage()) {
+      window.sessionStorage.removeItem(loginReloadKey);
+    }
 
     // 跳转到首页（由于状态已变更为loggedOut，HomeView会自动渲染PublicProfilesView）
     router.push({ path: '/' });


### PR DESCRIPTION
### Motivation
- 解决登录后页面出现空白（首屏渲染异常）的问题，通过在首次会话登录后进行一次性强制刷新来规避路由切换导致的渲染失败。
- 修复严格的 `Content-Security-Policy` 阻止字体和分析脚本加载的问题，允许加载 Google Fonts 与 Cloudflare Insights 相关资源以避免控制台错误和资源被拦截。

### Description
- 在 `src/stores/session.js` 中新增 `loginReloadKey` 与 `canUseSessionStorage`，并在 `login` 流程中加入一次性刷新逻辑：首次登录时写入 `sessionStorage` 标记并调用 `window.location.replace('/')` 强制刷新，随后正常使用 `router.push` 导航；在 `logout` 时清除该标记。
- 在 `functions/middleware/cors.js` 的 `securityHeadersMiddleware` 中放宽 `Content-Security-Policy`，在 `script-src` 中允许 `https://static.cloudflareinsights.com`，在 `style-src` 中允许 `https://fonts.googleapis.com`，并新增 `font-src` 允许 `https://fonts.gstatic.com` 与 `data:`，以允许字体与分析脚本加载。
- 保持原有的回退逻辑：当刷新标记已存在或无法使用 `sessionStorage` 时，仍使用 `router.push({ path: '/' })` 进行导航。
