### PR TITLE
移除登录后强制刷新、稳定路由视图渲染并放宽 CSP

### DIFF
--- a/functions/middleware/cors.js
+++ b/functions/middleware/cors.js
@@ -86,7 +86,7 @@ export async function securityHeadersMiddleware(request, next) {
     response.headers.set('Permissions-Policy', 'camera=(), microphone=(), geolocation=()');
     response.headers.set(
         'Content-Security-Policy',
-        "default-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; img-src 'self' data: blob:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; connect-src 'self' https: http:; worker-src 'self' blob:;"
+        "default-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; img-src 'self' data: blob:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https: http:; worker-src 'self' blob:;"
     );
 
     return response;

--- a/src/App.vue
+++ b/src/App.vue
@@ -153,9 +153,9 @@ const handleDiscard = async () => {
 
           <Suspense v-if="layoutMode === 'modern'">
             <template #default>
-              <router-view v-slot="{ Component }">
+              <router-view v-slot="{ Component, route: viewRoute }">
                 <transition name="fade" mode="out-in">
-                  <component :is="Component" />
+                  <component v-if="Component" :is="Component" :key="viewRoute.fullPath" />
                 </transition>
               </router-view>
             </template>
@@ -173,9 +173,9 @@ const handleDiscard = async () => {
        <template v-else-if="isPublicRoute">
          <Suspense>
            <template #default>
-             <router-view v-slot="{ Component }">
+             <router-view v-slot="{ Component, route: viewRoute }">
                <transition name="fade" mode="out-in">
-                 <component :is="Component" />
+                 <component v-if="Component" :is="Component" :key="viewRoute.fullPath" />
                </transition>
              </router-view>
            </template>

--- a/src/stores/session.js
+++ b/src/stores/session.js
@@ -11,7 +11,6 @@ export const useSessionStore = defineStore('session', () => {
   const initialData = ref(null);
   const publicConfig = ref({ enablePublicPage: true }); // Default true until fetched
   const isConfigReady = ref(false);
-
   async function checkSession() {
     try {
       // Parallel fetch of initial data (auth check) and public config


### PR DESCRIPTION
### Motivation
- 取消通过强制刷新掩盖登录后渲染异常的做法，改为修复渲染稳定性以避免错误提示被刷新一闪而过。 
- 通过稳定路由视图渲染根治首次登录后的空白/渲染失败问题。 
- 保留对内容安全策略的放宽以允许 Google Fonts 与 Cloudflare Insights 正常加载，避免资源被阻止导致的控制台错误。 

### Description
- 在 `src/stores/session.js` 中移除基于 `sessionStorage` 的 `loginReloadKey` 标记与 `window.location.replace('/')` 强制刷新逻辑，使登录后仅使用 `router.push({ path: '/' })` 进行导航。 
- 在 `src/App.vue` 的 `router-view` 插槽中引入 `route: viewRoute`，并为动态组件增加 `v-if=
