### PR TITLE
修复入口页登录后跳转并稳定路由视图；启用 PWA 自动更新与放宽 CSP

### DIFF
--- a/functions/middleware/cors.js
+++ b/functions/middleware/cors.js
@@ -86,7 +86,7 @@ export async function securityHeadersMiddleware(request, next) {
     response.headers.set('Permissions-Policy', 'camera=(), microphone=(), geolocation=()');
     response.headers.set(
         'Content-Security-Policy',
-        "default-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; img-src 'self' data: blob:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; connect-src 'self' https: http:; worker-src 'self' blob:;"
+        "default-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; img-src 'self' data: blob:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https: http:; worker-src 'self' blob:;"
     );
 
     return response;

--- a/src/App.vue
+++ b/src/App.vue
@@ -153,9 +153,9 @@ const handleDiscard = async () => {
 
           <Suspense v-if="layoutMode === 'modern'">
             <template #default>
-              <router-view v-slot="{ Component }">
+              <router-view v-slot="{ Component, route: viewRoute }">
                 <transition name="fade" mode="out-in">
-                  <component :is="Component" />
+                  <component v-if="Component" :is="Component" :key="viewRoute.fullPath" />
                 </transition>
               </router-view>
             </template>
@@ -173,9 +173,9 @@ const handleDiscard = async () => {
        <template v-else-if="isPublicRoute">
          <Suspense>
            <template #default>
-             <router-view v-slot="{ Component }">
+             <router-view v-slot="{ Component, route: viewRoute }">
                <transition name="fade" mode="out-in">
-                 <component :is="Component" />
+                 <component v-if="Component" :is="Component" :key="viewRoute.fullPath" />
                </transition>
              </router-view>
            </template>

--- a/src/stores/session.js
+++ b/src/stores/session.js
@@ -11,7 +11,6 @@ export const useSessionStore = defineStore('session', () => {
   const initialData = ref(null);
   const publicConfig = ref({ enablePublicPage: true }); // Default true until fetched
   const isConfigReady = ref(false);
-
   async function checkSession() {
     try {
       // Parallel fetch of initial data (auth check) and public config

--- a/src/views/Entrance.vue
+++ b/src/views/Entrance.vue
@@ -7,7 +7,7 @@
 
 <script setup>
 import { computed, defineAsyncComponent, ref, watch } from 'vue';
-import { useRoute } from 'vue-router';
+import { useRoute, useRouter } from 'vue-router';
 import { storeToRefs } from 'pinia';
 import { useSessionStore } from '../stores/session';
 import LoadingSpinner from '../components/ui/LoadingSpinner.vue';
@@ -17,6 +17,7 @@ const Login = defineAsyncComponent(() => import('../components/modals/Login.vue'
 const NotFound = defineAsyncComponent(() => import('./NotFound.vue'));
 
 const route = useRoute();
+const router = useRouter();
 const sessionStore = useSessionStore();
 const { publicConfig, isConfigReady, sessionState } = storeToRefs(sessionStore);
 
@@ -30,7 +31,16 @@ watch([() => route.path, publicConfig, isConfigReady], () => {
     }
 }, { immediate: true });
 
+watch(sessionState, (state) => {
+    if (state === 'loggedIn' && route.path !== '/') {
+        router.replace('/');
+    }
+}, { immediate: true });
+
 async function checkPath() {
+    if (sessionState.value === 'loggedIn') {
+        return;
+    }
     // 1. Get Configured Path
     // Settings might be in initialData (if logged in) or publicConfig (if not)
     // Actually, 'customLoginPath' might be considered a 'secret' setting? 

--- a/vite.config.js
+++ b/vite.config.js
@@ -9,8 +9,10 @@ export default defineConfig({
     vue(),
     tailwindcss(),
     VitePWA({
-      registerType: 'prompt',
+      registerType: 'autoUpdate',
       workbox: {
+        skipWaiting: true,
+        clientsClaim: true,
         globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2}'],
         cleanupOutdatedCaches: true,
         // 使用离线回退页面，并显式忽略订阅路径


### PR DESCRIPTION
### Motivation
- 解决在新布局下用户登录后仍然停留在入口页并继续显示登录框的问题。 
- 避免路由视图复用/未重新渲染导致的旧组件残留问题。 
- 通过让 PWA 自动更新并在激活时接管，尽快清理旧缓存以减少版本不一致导致的异常。 
- 放宽内容安全策略以允许 Google Fonts 与 Cloudflare Insights 正常加载，避免被阻止的资源触发控制台错误。 

### Description
- 在 `src/views/Entrance.vue` 中引入 `useRouter`，监听 `sessionState`，当状态为 `loggedIn` 且当前不是首页时执行 `router.replace('/')`，并在 `checkPath` 中在已登录时直接返回以跳过入口页选择逻辑。 
- 在 `src/App.vue` 的 `router-view` 插槽中引入 `route: viewRoute`，对动态组件添加 `v-if=
