### PR TITLE
修复登录后入口组件空渲染报错

### DIFF
--- a/src/views/Entrance.vue
+++ b/src/views/Entrance.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="entrance-container">
      <LoadingSpinner v-if="isLoading" type="spinner" size="md" color="indigo" message="正在加载..." />
+     <LoadingSpinner v-else-if="!activeComponent" type="spinner" size="md" color="indigo" message="正在准备页面..." />
      <component v-else :is="activeComponent" v-bind="componentProps" />
   </div>
 </template>
@@ -23,7 +24,7 @@ const { publicConfig, isConfigReady, sessionState } = storeToRefs(sessionStore);
 
 const activeComponent = ref(null);
 const componentProps = ref({});
-const isLoading = computed(() => !isConfigReady.value || sessionState.value === 'loading');
+const isLoading = computed(() => !isConfigReady.value || sessionState.value === 'loading' || sessionState.value === 'loggedIn');
 
 watch([() => route.path, publicConfig, isConfigReady], () => {
     if (isConfigReady.value) {
@@ -39,6 +40,8 @@ watch(sessionState, (state) => {
 
 async function checkPath() {
     if (sessionState.value === 'loggedIn') {
+        activeComponent.value = null;
+        componentProps.value = {};
         return;
     }
     // 1. Get Configured Path
@@ -89,6 +92,7 @@ async function checkPath() {
     } else {
         // Not a login path, and fell through to catch-all
         activeComponent.value = NotFound;
+        componentProps.value = {};
     }
 }
 


### PR DESCRIPTION
### Motivation
- 修复在登录态或路由跳转期间 `Entrance.vue` 可能渲染空组件导致 Vue 报错的问题，并在入口页提供占位加载以避免闪烁和异常。

### Description
- 在 `src/views/Entrance.vue` 中：当 `sessionState === 'loggedIn'` 时清理 `activeComponent` 与 `componentProps`，将 `isLoading` 扩展为在已登录时也为真，并新增 `v-else-if="!activeComponent"` 的“正在准备页面...”占位 `LoadingSpinner` 来避免渲染空组件。

### Testing
- 启动开发服务器并截图验证页面行为：执行 `npm run dev -- --host 0.0.0.0 --port 4173` 启动 Vite，并用 Playwright 脚本访问 `http://127.0.0.1:4173/login` 生成截图以确认占位加载和路由跳转逻辑；期间代理请求出现 `ECONNREFUSED`（后端未运行），但页面占位与渲染行为正常；未运行单元测试。
