### PR TITLE
修复登录流程的会话存储检测与入口渲染错误

### DIFF
--- a/src/stores/session.js
+++ b/src/stores/session.js
@@ -6,6 +6,22 @@ import { api } from '../lib/http.js';
 import { useDataStore } from './useDataStore';
 import router from '../router';
 
+const loginReloadKey = 'misub_login_reloaded';
+
+function canUseSessionStorage() {
+  try {
+    if (typeof window === 'undefined' || !window.sessionStorage) {
+      return false;
+    }
+    const testKey = '__misub_session_test__';
+    window.sessionStorage.setItem(testKey, '1');
+    window.sessionStorage.removeItem(testKey);
+    return true;
+  } catch (error) {
+    return false;
+  }
+}
+
 export const useSessionStore = defineStore('session', () => {
   const sessionState = ref('loading'); // loading, loggedIn, loggedOut
   const initialData = ref(null);

--- a/src/views/Entrance.vue
+++ b/src/views/Entrance.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="entrance-container">
      <LoadingSpinner v-if="isLoading" type="spinner" size="md" color="indigo" message="正在加载..." />
+     <LoadingSpinner v-else-if="!activeComponent" type="spinner" size="md" color="indigo" message="正在准备页面..." />
      <component v-else :is="activeComponent" v-bind="componentProps" />
   </div>
 </template>
@@ -23,7 +24,7 @@ const { publicConfig, isConfigReady, sessionState } = storeToRefs(sessionStore);
 
 const activeComponent = ref(null);
 const componentProps = ref({});
-const isLoading = computed(() => !isConfigReady.value || sessionState.value === 'loading');
+const isLoading = computed(() => !isConfigReady.value || sessionState.value === 'loading' || sessionState.value === 'loggedIn');
 
 watch([() => route.path, publicConfig, isConfigReady], () => {
     if (isConfigReady.value) {
@@ -39,6 +40,8 @@ watch(sessionState, (state) => {
 
 async function checkPath() {
     if (sessionState.value === 'loggedIn') {
+        activeComponent.value = null;
+        componentProps.value = {};
         return;
     }
     // 1. Get Configured Path
@@ -89,6 +92,7 @@ async function checkPath() {
     } else {
         // Not a login path, and fell through to catch-all
         activeComponent.value = NotFound;
+        componentProps.value = {};
     }
 }
 


### PR DESCRIPTION
### Motivation
- 修复点击退出再登录时页面出现大量报错与空白的问题，避免因未定义的 `canUseSessionStorage` 或在登录/路由切换期间渲染空组件导致 Vue 异常。
- 提高在不支持或被浏览器禁用 `sessionStorage` 场景下的健壮性，防止直接访问 `window.sessionStorage` 抛出异常。

### Description
- 在 `src/stores/session.js` 中新增常量 `loginReloadKey` 并实现 `canUseSessionStorage()` 检测函数，使用 `try/catch` 与写入测试键来判断 `sessionStorage` 是否可用以避免异常。
- 在 `src/views/Entrance.vue` 中新增当 `!activeComponent` 时的占位 `LoadingSpinner`，并将 `isLoading` 计算属性扩展为在 `sessionState === 'loggedIn'` 时也为真以防止短暂空渲染。
- 在 `Entrance.vue` 的路径检查逻辑中，登录态时清空 `activeComponent` 与 `componentProps`，以及在 `NotFound` 分支确保 `componentProps` 被重置为 `{}`，从而避免组件接收到未定义 props 导致错误。
