### PR TITLE
fix: 提升手动节点处理容错，避免 TG Bot 添加节点导致订阅组生成失败

### DIFF
--- a/tests/unit/node-utils.test.js
+++ b/tests/unit/node-utils.test.js
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { prependNodeName } from '../../functions/utils/node-utils.js';
+
+describe('node-utils', () => {
+    it('prependNodeName 应在 hash 非法编码时安全回退而不是抛错', () => {
+        const malformed = 'vless://uuid@example.com:443?security=tls#%E0%A4%A';
+
+        expect(() => prependNodeName(malformed, '手动节点')).not.toThrow();
+
+        const renamed = prependNodeName(malformed, '手动节点');
+        expect(renamed).toContain('#');
+        expect(decodeURIComponent(renamed.split('#')[1])).toContain('手动节点');
+    });
+});

--- a/tests/unit/subscription-service-manual-nodes.test.js
+++ b/tests/unit/subscription-service-manual-nodes.test.js
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { generateCombinedNodeList } from '../../functions/services/subscription-service.js';
+
+describe('subscription-service 手动节点健壮性', () => {
+    it('应在包含异常节点时跳过坏节点并继续生成订阅', async () => {
+        const misubs = [
+            {
+                id: 'bad-1',
+                name: '坏节点',
+                // 故意传非字符串，模拟历史脏数据
+                url: null,
+                enabled: true
+            },
+            {
+                id: 'bad-2',
+                name: '坏节点2',
+                // 非法编码，历史导入可能出现
+                url: 'vless://uuid@example.com:443?security=tls#%E0%A4%A',
+                enabled: true
+            },
+            {
+                id: 'ok-1',
+                name: '正常节点',
+                url: 'trojan://pass@example.com:443#ok',
+                enabled: true
+            }
+        ];
+
+        const result = await generateCombinedNodeList(
+            {},
+            { enableAccessLog: false },
+            'ClashMeta',
+            misubs,
+            '',
+            {
+                enableManualNodes: true,
+                manualNodePrefix: '手动节点',
+                enableSubscriptions: true
+            },
+            false
+        );
+
+        expect(typeof result).toBe('string');
+        expect(result).toContain('trojan://pass@example.com:443#');
+        expect(result).toContain(encodeURIComponent('手动节点 - 正常节点'));
+    });
+});


### PR DESCRIPTION
### Motivation
- 修复 TG Bot/手动添加的节点在含有非法 hash 编码或脏数据时，导致订阅生成链路被中断（客户端订阅失败，如 Worker 1101）。
- 增强对历史脏数据（非字符串 URL / 非法百分号编码 / 解码异常）的鲁棒性，避免单条手工节点破坏整个订阅输出。

### Description
- 在 `functions/services/subscription-service.js` 的 `generateCombinedNodeList` 中将手动节点处理改为逐条隔离处理：仅处理字符串 URL、为每条节点包裹 `try/catch`、异常时跳过当前节点并记录警告，最终过滤空项再拼接输出。
- 在 `functions/utils/node-utils.js` 中对 `prependNodeName` 的 fragment 解码增加 `try/catch` 回退逻辑，避免非法百分号编码导致 `decodeURIComponent` 抛错；并在 `fixNodeUrlEncoding` 增加对非字符串输入的早期返回保护，以及在成功修正 base64 部分后正确返回重组的 `baseLink + fragment`。
- 保留对 vmess/vless/ss 等协议的原有处理逻辑，且在 `generateCombinedNodeList` 中当 `fixNodeUrlEncoding` 返回异常或空结果时回退使用原始 URL，避免链路中断。
- 新增单元测试 `tests/unit/node-utils.test.js` 和 `tests/unit/subscription-service-manual-nodes.test.js`，覆盖非法 hash 编码与“异常节点 + 正常节点混合”场景。