### PR TITLE
fix: 修复 Clash 订阅生成时的节点重名问题

### DIFF
--- a/functions/modules/subscription/builtin-clash-generator.js
+++ b/functions/modules/subscription/builtin-clash-generator.js
@@ -71,6 +71,20 @@ export function generateBuiltinClashConfig(nodeList, options = {}) {
     // 清理控制字符
     proxies = deepCleanControlChars(proxies);
 
+    // 处理重名节点
+    const usedNames = new Set();
+    proxies.forEach(proxy => {
+        let name = proxy.name;
+        if (usedNames.has(name)) {
+            let i = 1;
+            while (usedNames.has(`${name}_${i}`)) {
+                i++;
+            }
+            proxy.name = `${name}_${i}`;
+        }
+        usedNames.add(proxy.name);
+    });
+
     if (proxies.length === 0) {
         return '# No valid proxies found\nproxies: []\n';
     }


### PR DESCRIPTION
当订阅源包含多个同名节点时，生成的 Clash 配置文件会因 `proxy name duplicate` 报错。 此提交在 [builtin-clash-generator.js](https://github.com/15515151/MiSub/blob/57b978140f39c4ae011138a0e9c277f2eefa8dc6/functions/modules/subscription/builtin-clash-generator.js#L75) 中添加了名称去重逻辑：
- 自动检测重复的节点名称。
- 对重复名称自动添加递增后缀（例如：`节点A` -> `节点A_1`），确保所有代理名称唯一。