### PR TITLE
Support optional SYNC_PAT for pushing workflow changes and prefer upstream on merge conflicts

### DIFF
--- a/.github/workflows/fork-sync.yml
+++ b/.github/workflows/fork-sync.yml
@@ -18,11 +18,13 @@ jobs:
       - name: Checkout target repo
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.SYNC_PAT != '' && secrets.SYNC_PAT || secrets.GITHUB_TOKEN }}
           fetch-depth: 0
           ref: main
 
       - name: Configure Git & remotes
+        env:
+          SYNC_PAT: ${{ secrets.SYNC_PAT }}
         run: |
           set -e
           git config user.name "GitHub Actions Bot"
@@ -38,12 +40,24 @@ jobs:
             git remote add upstream https://github.com/imzyb/MiSub.git
           fi
 
+          # 若配置了带 workflows 权限的 PAT，则强制 origin 使用该令牌推送
+          if [ -n "${SYNC_PAT:-}" ]; then
+            git remote set-url origin "https://x-access-token:${SYNC_PAT}@github.com/${{ github.repository }}.git"
+            echo "检测到 SYNC_PAT，将使用 PAT 推送（可同步 workflow 变更）"
+          else
+            echo "未配置 SYNC_PAT，将使用 GITHUB_TOKEN 推送"
+          fi
+
           git fetch --prune upstream
           git fetch --prune origin
 
       - name: Merge from upstream and resolve conflicts (prefer upstream)
         id: merge_attempt
         run: |
+          # 记录合并前基线，后续用于必要时回滚 workflow 文件
+          BASE_REF=$(git rev-parse HEAD)
+          echo "BASE_REF=$BASE_REF" >> "$GITHUB_ENV"
+
           # 不使用 set -e，因为 git merge 冲突时返回非零退出码是正常行为
           MERGE_FAILED=false
 
@@ -77,7 +91,19 @@ jobs:
           fi
 
       - name: Commit and Push (if changed)
+        env:
+          SYNC_PAT: ${{ secrets.SYNC_PAT }}
         run: |
+          set -e
+
+          # 未配置 PAT 时，GITHUB_TOKEN 默认无法更新 workflow 文件，推送前回滚该目录
+          if [ -z "${SYNC_PAT:-}" ]; then
+            if [ -n "${BASE_REF:-}" ] && git ls-tree -d --name-only "$BASE_REF" .github/workflows >/dev/null 2>&1; then
+              git restore --source "$BASE_REF" --staged --worktree .github/workflows || true
+              echo "未配置 SYNC_PAT：已回滚 .github/workflows 变更，避免权限拒绝"
+            fi
+          fi
+
           # 检查是否有正在进行的合并（冲突解决后需提交）
           if [ -f .git/MERGE_HEAD ]; then
              echo "Conflict resolved, committing merge..."
@@ -94,4 +120,3 @@ jobs:
           else
              echo "No changes to push."
           fi
-


### PR DESCRIPTION
### Motivation

- Enable forks to sync upstream workflow changes when a PAT with `workflows` permission is provided and otherwise avoid pushing workflow changes with the limited `GITHUB_TOKEN`.
- Ensure merges from upstream prefer upstream versions on conflicts to keep the fork aligned with upstream.

### Description

- Use `secrets.SYNC_PAT` when present as the checkout token and set `origin` remote to `https://x-access-token:${SYNC_PAT}@...` so pushes can include workflow updates.  
- Record `BASE_REF` before merging and fetch/prune both `upstream` and `origin` to establish a safe rollback point.  
- Attempt `git merge upstream/main`, detect conflicted files and resolve conflicts by checking out `--theirs` (upstream) for each conflict, then add and commit the merge.  
- If `SYNC_PAT` is not set, restore `.github/workflows` from `BASE_REF` before pushing to avoid permission errors when using `GITHUB_TOKEN`.

### Testing

- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e38018a2c832a93004c9091875111)