### PR TITLE
Fix D1 system stats and move access logs off KV in D1 mode

### DIFF
--- a/functions/modules/handlers/debug-handler.js
+++ b/functions/modules/handlers/debug-handler.js
@@ -115,8 +115,14 @@ export async function handleSystemInfoRequest(request, env) {
         const storageAdapter = StorageFactory.createAdapter(env, storageType);
 
         // 获取基本统计信息
-        const allSubscriptions = await storageAdapter.get('misub_subscriptions_v1') || [];
-        const allProfiles = await storageAdapter.get('misub_profiles_v1') || [];
+        const [allSubscriptions, allProfiles] = await Promise.all([
+            typeof storageAdapter.getAllSubscriptions === 'function'
+                ? storageAdapter.getAllSubscriptions()
+                : storageAdapter.get('misub_subscriptions_v1').then(res => res || []),
+            typeof storageAdapter.getAllProfiles === 'function'
+                ? storageAdapter.getAllProfiles()
+                : storageAdapter.get('misub_profiles_v1').then(res => res || [])
+        ]);
 
         const activeSubscriptions = allSubscriptions.filter(sub => sub.enabled).length;
         const activeProfiles = allProfiles.filter(profile => profile.enabled).length;

--- a/functions/services/log-service.js
+++ b/functions/services/log-service.js
@@ -3,6 +3,8 @@
  * 处理订阅访问日志的存储和检索
  */
 
+import { StorageFactory, STORAGE_TYPES } from '../storage-adapter.js';
+
 const LOG_KV_KEY = 'misub_system_logs';
 const LOG_INDEX_KV_KEY = 'misub_system_logs:index';
 const LOG_BUCKET_PREFIX = 'misub_system_logs:';
@@ -13,8 +15,35 @@ const SUCCESS_LOG_COOLDOWN_MS = 5 * 60 * 1000;
 const ERROR_LOG_COOLDOWN_MS = 60 * 1000;
 const MAX_PERSISTED_LOGS_PER_MINUTE = 12;
 
-function getKV(env) {
-    return env?.MISUB_KV || null;
+async function resolvePrimaryLogStorage(env) {
+    const storageType = await StorageFactory.getStorageType(env);
+    const storage = StorageFactory.createAdapter(env, storageType);
+    if (!storage || typeof storage.get !== 'function' || typeof storage.put !== 'function' || typeof storage.delete !== 'function') {
+        return null;
+    }
+
+    return {
+        storageType: storage.type || storageType,
+        storage
+    };
+}
+
+function resolveLegacyLogStorage(env, primaryStorageType) {
+    if (primaryStorageType !== STORAGE_TYPES.D1) {
+        return null;
+    }
+
+    const kv = StorageFactory.resolveKV(env);
+    if (!kv) {
+        return null;
+    }
+
+    const storage = StorageFactory.createAdapter(env, STORAGE_TYPES.KV);
+    if (!storage || typeof storage.get !== 'function' || typeof storage.put !== 'function' || typeof storage.delete !== 'function') {
+        return null;
+    }
+
+    return storage;
 }
 
 function getLogBucketKey(timestamp) {
@@ -25,15 +54,28 @@ function getLogBucketKey(timestamp) {
     return `${LOG_BUCKET_PREFIX}${yyyy}-${mm}-${dd}`;
 }
 
-async function getLogBucketIndex(kv) {
-    const raw = await kv.get(LOG_INDEX_KV_KEY);
-    const index = raw ? JSON.parse(raw) : null;
+async function getLogBucketIndex(storage) {
+    const index = await storage.get(LOG_INDEX_KV_KEY);
     return Array.isArray(index) ? index : [];
 }
 
-async function saveLogBucketIndex(kv, keys) {
+async function saveLogBucketIndex(storage, keys) {
     const unique = Array.from(new Set(keys)).sort().reverse();
-    await kv.put(LOG_INDEX_KV_KEY, JSON.stringify(unique.slice(0, MAX_LOG_AGE_DAYS + 2)));
+    await storage.put(LOG_INDEX_KV_KEY, unique.slice(0, MAX_LOG_AGE_DAYS + 2));
+}
+
+async function readLogsFromStorage(storage) {
+    const [bucketIndex, legacyLogs] = await Promise.all([
+        getLogBucketIndex(storage),
+        storage.get(LOG_KV_KEY)
+    ]);
+
+    const bucketEntries = await Promise.all(
+        bucketIndex.map(key => storage.get(key).then(raw => Array.isArray(raw) ? raw : []).catch(() => []))
+    );
+
+    return [...bucketEntries.flat(), ...(Array.isArray(legacyLogs) ? legacyLogs : [])]
+        .filter(log => (Date.now() - log.timestamp) <= MAX_LOG_AGE_MS);
 }
 // 全局内存队列，用于削峰填谷和防写竞争
 let logBatch = [];
@@ -94,7 +136,8 @@ export const LogService = {
      * @param {Object} logEntry - 日志内容
      */
     async addLog(env, logEntry) {
-        if (!getKV(env)) return;
+        const primaryStorage = await resolvePrimaryLogStorage(env);
+        if (!primaryStorage) return;
         if (!shouldPersistLog(logEntry)) return null;
 
         const enrichedLog = {
@@ -132,10 +175,15 @@ export const LogService = {
         logBatch = [];
 
         try {
-            const kv = getKV(env);
+            const primaryStorage = await resolvePrimaryLogStorage(env);
+            if (!primaryStorage) {
+                return;
+            }
+
+            const { storage } = primaryStorage;
             const now = Date.now();
             const bucketKey = getLogBucketKey(now);
-            let logs = await kv.get(bucketKey).then(r => r ? JSON.parse(r) : null) || [];
+            let logs = await storage.get(bucketKey);
             if (!Array.isArray(logs)) logs = [];
 
             // 把新收集到的一批日志插入到头部 (倒序输入保证时间线不乱)
@@ -150,9 +198,9 @@ export const LogService = {
                 logs = logs.slice(0, perBucketLimit);
             }
 
-            await kv.put(bucketKey, JSON.stringify(logs));
+            await storage.put(bucketKey, logs);
 
-            const bucketIndex = await getLogBucketIndex(kv);
+            const bucketIndex = await getLogBucketIndex(storage);
             if (!bucketIndex.includes(bucketKey)) {
                 bucketIndex.push(bucketKey);
             }
@@ -163,7 +211,7 @@ export const LogService = {
                 return !Number.isNaN(bucketTime) && (now - bucketTime) <= (MAX_LOG_AGE_MS + 24 * 60 * 60 * 1000);
             });
 
-            await saveLogBucketIndex(kv, validBucketKeys);
+            await saveLogBucketIndex(storage, validBucketKeys);
         } catch (error) {
             console.error('[LogService] Failed to flush batch logs:', error);
             // 写入失败时尝试把日志塞回队列前部
@@ -184,25 +232,17 @@ export const LogService = {
      * @param {Object} env - Cloudflare Environment
      */
     async getLogs(env) {
-        const kv = getKV(env);
-        if (!kv) return [];
         try {
-            const [bucketIndex, legacyRaw] = await Promise.all([
-                getLogBucketIndex(kv),
-                kv.get(LOG_KV_KEY)
-            ]);
+            const primaryStorage = await resolvePrimaryLogStorage(env);
+            if (!primaryStorage) return [];
 
-            const bucketEntries = await Promise.all(
-                bucketIndex.map(key => kv.get(key).then(raw => raw ? JSON.parse(raw) : []).catch(() => []))
-            );
+            const logs = await readLogsFromStorage(primaryStorage.storage);
+            const legacyStorage = resolveLegacyLogStorage(env, primaryStorage.storageType);
+            const legacyLogs = legacyStorage ? await readLogsFromStorage(legacyStorage) : [];
 
-            const legacyLogs = legacyRaw ? JSON.parse(legacyRaw) : null;
-            const logs = [...bucketEntries.flat(), ...(Array.isArray(legacyLogs) ? legacyLogs : [])]
-                .filter(log => (Date.now() - log.timestamp) <= MAX_LOG_AGE_MS)
+            return [...logs, ...legacyLogs]
                 .sort((a, b) => b.timestamp - a.timestamp)
                 .slice(0, MAX_LOG_ENTRIES);
-
-            return logs;
         } catch (error) {
             console.error('[LogService] Failed to get logs:', error);
             return [];
@@ -214,15 +254,24 @@ export const LogService = {
      * @param {Object} env - Cloudflare Environment
      */
     async clearLogs(env) {
-        const kv = getKV(env);
-        if (!kv) return;
         try {
-            const bucketIndex = await getLogBucketIndex(kv);
-            await Promise.all([
-                kv.delete(LOG_KV_KEY),
-                kv.delete(LOG_INDEX_KV_KEY),
-                ...bucketIndex.map(key => kv.delete(key))
-            ]);
+            const primaryStorage = await resolvePrimaryLogStorage(env);
+            if (!primaryStorage) return false;
+
+            const storages = [primaryStorage.storage];
+            const legacyStorage = resolveLegacyLogStorage(env, primaryStorage.storageType);
+            if (legacyStorage && legacyStorage !== primaryStorage.storage) {
+                storages.push(legacyStorage);
+            }
+
+            await Promise.all(storages.map(async storage => {
+                const bucketIndex = await getLogBucketIndex(storage);
+                await Promise.all([
+                    storage.delete(LOG_KV_KEY),
+                    storage.delete(LOG_INDEX_KV_KEY),
+                    ...bucketIndex.map(key => storage.delete(key))
+                ]);
+            }));
             return true;
         } catch (error) {
             console.error('[LogService] Failed to clear logs:', error);

--- a/tests/unit/debug-handler-system-info.test.js
+++ b/tests/unit/debug-handler-system-info.test.js
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getAllSubscriptions = vi.fn();
+const getAllProfiles = vi.fn();
+const get = vi.fn();
+const createAdapter = vi.fn();
+const getStorageType = vi.fn();
+const hasDualStorage = vi.fn();
+const resolveKV = vi.fn();
+
+vi.mock('../../functions/storage-adapter.js', () => ({
+  StorageFactory: {
+    createAdapter: (...args) => createAdapter(...args),
+    getStorageType: (...args) => getStorageType(...args),
+    hasDualStorage: (...args) => hasDualStorage(...args),
+    resolveKV: (...args) => resolveKV(...args)
+  }
+}));
+
+vi.mock('../../functions/modules/utils.js', () => ({
+  createJsonResponse: (data, status = 200) => new Response(JSON.stringify(data), { status }),
+  createErrorResponse: (data, status = 500) => new Response(JSON.stringify({ error: String(data) }), { status })
+}));
+
+vi.mock('../../functions/modules/subscription-handler.js', () => ({
+  handleSubscriptionNodesRequest: vi.fn()
+}));
+
+vi.mock('../../functions/services/notification-service.js', () => ({
+  debugTgNotification: vi.fn()
+}));
+
+vi.mock('../../functions/modules/utils/node-parser.js', () => ({
+  parseNodeList: vi.fn(),
+  calculateProtocolStats: vi.fn(),
+  calculateRegionStats: vi.fn()
+}));
+
+describe('handleSystemInfoRequest', () => {
+  beforeEach(() => {
+    getAllSubscriptions.mockReset();
+    getAllProfiles.mockReset();
+    get.mockReset();
+    createAdapter.mockReset();
+    getStorageType.mockReset();
+    hasDualStorage.mockReset();
+    resolveKV.mockReset();
+
+    getStorageType.mockResolvedValue('d1');
+    hasDualStorage.mockReturnValue(true);
+    resolveKV.mockReturnValue({});
+    createAdapter.mockReturnValue({
+      getAllSubscriptions,
+      getAllProfiles,
+      get
+    });
+    get.mockResolvedValue([]);
+  });
+
+  it('uses row-level helper APIs for D1-backed statistics', async () => {
+    const { handleSystemInfoRequest } = await import('../../functions/modules/handlers/debug-handler.js');
+
+    getAllSubscriptions.mockResolvedValue([
+      { id: 'sub-1', enabled: true },
+      { id: 'sub-2', enabled: false }
+    ]);
+    getAllProfiles.mockResolvedValue([
+      { id: 'profile-1', enabled: true },
+      { id: 'profile-2', enabled: false },
+      { id: 'profile-3', enabled: true }
+    ]);
+
+    const response = await handleSystemInfoRequest(
+      { method: 'GET' },
+      { MISUB_DB: {}, MISUB_KV: {}, ADMIN_PASSWORD: 'x', COOKIE_SECRET: 'y' }
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(getAllSubscriptions).toHaveBeenCalled();
+    expect(getAllProfiles).toHaveBeenCalled();
+    expect(payload.systemInfo.statistics.subscriptions).toEqual({
+      total: 2,
+      active: 1,
+      inactive: 1
+    });
+    expect(payload.systemInfo.statistics.profiles).toEqual({
+      total: 3,
+      active: 2,
+      inactive: 1
+    });
+  });
+});

--- a/tests/unit/log-service-storage.test.js
+++ b/tests/unit/log-service-storage.test.js
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const createAdapter = vi.fn();
+const getStorageType = vi.fn();
+const resolveKV = vi.fn();
+
+vi.mock('../../functions/storage-adapter.js', () => ({
+  StorageFactory: {
+    createAdapter: (...args) => createAdapter(...args),
+    getStorageType: (...args) => getStorageType(...args),
+    resolveKV: (...args) => resolveKV(...args)
+  },
+  STORAGE_TYPES: {
+    KV: 'kv',
+    D1: 'd1'
+  }
+}));
+
+function createMemoryStorage(type) {
+  const store = new Map();
+
+  return {
+    type,
+    store,
+    async get(key) {
+      return store.has(key) ? store.get(key) : null;
+    },
+    async put(key, value) {
+      store.set(key, value);
+      return true;
+    },
+    async delete(key) {
+      store.delete(key);
+      return true;
+    }
+  };
+}
+
+describe('LogService storage selection', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-15T00:00:00Z'));
+    vi.resetModules();
+
+    createAdapter.mockReset();
+    getStorageType.mockReset();
+    resolveKV.mockReset();
+
+    getStorageType.mockResolvedValue('d1');
+    resolveKV.mockReturnValue({});
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('writes access logs into D1-backed storage when storageType is d1', async () => {
+    const d1Storage = createMemoryStorage('d1');
+    const kvStorage = createMemoryStorage('kv');
+
+    createAdapter.mockImplementation((env, type) => (type === 'd1' ? d1Storage : kvStorage));
+
+    const { LogService } = await import('../../functions/services/log-service.js');
+
+    const addLogPromise = LogService.addLog(
+      { MISUB_DB: {}, MISUB_KV: {} },
+      {
+        status: 'success',
+        type: 'profile',
+        token: 'profile-token',
+        format: 'builtin-clash',
+        domain: 'sub.example.com',
+        summary: '生成 10 个节点 (成功: 10, 失败: 0)'
+      }
+    );
+
+    await vi.advanceTimersByTimeAsync(500);
+    await addLogPromise;
+
+    expect(Array.from(d1Storage.store.keys())).toContain('misub_system_logs:index');
+    expect(Array.from(kvStorage.store.keys())).not.toContain('misub_system_logs:index');
+
+    const logs = await LogService.getLogs({ MISUB_DB: {}, MISUB_KV: {} });
+    expect(logs).toHaveLength(1);
+    expect(logs[0]).toMatchObject({
+      token: 'profile-token',
+      format: 'builtin-clash',
+      domain: 'sub.example.com'
+    });
+  });
+
+  it('clears both D1 logs and legacy KV log buckets in d1 mode', async () => {
+    const d1Storage = createMemoryStorage('d1');
+    const kvStorage = createMemoryStorage('kv');
+
+    d1Storage.store.set('misub_system_logs:index', ['misub_system_logs:2026-04-15']);
+    d1Storage.store.set('misub_system_logs:2026-04-15', [{ id: 'd1-log', timestamp: Date.now() }]);
+
+    kvStorage.store.set('misub_system_logs:index', ['misub_system_logs:2026-04-14']);
+    kvStorage.store.set('misub_system_logs:2026-04-14', [{ id: 'kv-log', timestamp: Date.now() }]);
+
+    createAdapter.mockImplementation((env, type) => (type === 'd1' ? d1Storage : kvStorage));
+
+    const { LogService } = await import('../../functions/services/log-service.js');
+
+    const result = await LogService.clearLogs({ MISUB_DB: {}, MISUB_KV: {} });
+
+    expect(result).toBe(true);
+    expect(d1Storage.store.size).toBe(0);
+    expect(kvStorage.store.size).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- fix /api/system/info so D1 row-level storage reports real subscription/profile counts
- route access log writes through the active storage backend so D1 deployments stop writing new logs into KV
- keep legacy KV log buckets readable/clearable during D1 rollout and cover both changes with unit tests

## Validation
- 
pm run test:run -- tests/unit/debug-handler-system-info.test.js tests/unit/log-service-storage.test.js tests/unit/storage-adapter-row-level.test.js
- 
pm run build

## Notes
- the current upstream test 	ests/unit/api-handler-storage-helpers.test.js still has an existing expectation mismatch unrelated to this change (sortIndex in row-level save payload)