### PR TITLE
fix: keep /cron working with D1 row-level subscriptions

### DIFF
--- a/functions/modules/notifications.js
+++ b/functions/modules/notifications.js
@@ -35,6 +35,27 @@ export async function sendEnhancedTgNotification(settings, type, clientIp, addit
     return sendCoreEnhancedTg(settings, type, clientIp, additionalData);
 }
 
+async function loadSubscriptionsForCron(storageAdapter) {
+    if (typeof storageAdapter.getAllSubscriptions === 'function') {
+        const subscriptions = await storageAdapter.getAllSubscriptions();
+        if (Array.isArray(subscriptions)) {
+            return subscriptions;
+        }
+    }
+
+    const subscriptions = await storageAdapter.get(KV_KEY_SUBS);
+    return Array.isArray(subscriptions) ? subscriptions : [];
+}
+
+async function persistSubscriptionsForCron(storageAdapter, subscriptions) {
+    if (typeof storageAdapter.putAllSubscriptions === 'function') {
+        await storageAdapter.putAllSubscriptions(subscriptions);
+        return;
+    }
+
+    await storageAdapter.put(KV_KEY_SUBS, subscriptions);
+}
+
 /**
  * 检查并发送订阅到期和流量预警通知
  */
@@ -95,7 +116,7 @@ export async function handleCronTrigger(env) {
     const { StorageFactory } = await import('../storage-adapter.js');
 
     const storageAdapter = await StorageFactory.createAdapter(env, await StorageFactory.getStorageType(env));
-    const originalSubs = await storageAdapter.get(KV_KEY_SUBS) || [];
+    const originalSubs = await loadSubscriptionsForCron(storageAdapter);
     const allSubs = JSON.parse(JSON.stringify(originalSubs));
     const settings = await storageAdapter.get(KV_KEY_SETTINGS) || DEFAULT_SETTINGS;
 
@@ -239,7 +260,7 @@ export async function handleCronTrigger(env) {
     }
 
     if (changesMade) {
-        await storageAdapter.put(KV_KEY_SUBS, allSubs);
+        await persistSubscriptionsForCron(storageAdapter, allSubs);
     }
 
     const duration = Date.now() - startTime;

--- a/tests/unit/notifications-cron-storage.test.js
+++ b/tests/unit/notifications-cron-storage.test.js
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getAllSubscriptions = vi.fn();
+const get = vi.fn();
+const putAllSubscriptions = vi.fn();
+const createAdapter = vi.fn();
+const getStorageType = vi.fn();
+
+vi.mock('../../functions/storage-adapter.js', () => ({
+  StorageFactory: {
+    createAdapter: (...args) => createAdapter(...args),
+    getStorageType: (...args) => getStorageType(...args)
+  }
+}));
+
+vi.mock('../../functions/services/notification-service.js', () => ({
+  sendTgNotification: vi.fn().mockResolvedValue(false),
+  sendEnhancedTgNotification: vi.fn().mockResolvedValue(false),
+  tgEscape: (value) => value
+}));
+
+describe('notifications cron storage helper usage', () => {
+  beforeEach(() => {
+    getAllSubscriptions.mockReset();
+    get.mockReset();
+    putAllSubscriptions.mockReset();
+    createAdapter.mockReset();
+    getStorageType.mockReset();
+
+    getStorageType.mockResolvedValue('d1');
+    createAdapter.mockReturnValue({
+      type: 'd1',
+      getAllSubscriptions,
+      get,
+      putAllSubscriptions
+    });
+    get.mockImplementation(async (key) => {
+      if (key === 'worker_settings_v1') {
+        return {};
+      }
+      return null;
+    });
+    putAllSubscriptions.mockResolvedValue(true);
+
+    vi.stubGlobal('fetch', vi.fn().mockImplementation(async () => ({
+      ok: true,
+      headers: {
+        get(name) {
+          return String(name).toLowerCase() === 'subscription-userinfo'
+            ? 'upload=1; download=2; total=10'
+            : null;
+        }
+      },
+      async text() {
+        return 'ss://node-one\nvmess://node-two';
+      }
+    })));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('handleCronTrigger prefers row-level subscription helpers for D1 storage', async () => {
+    const { handleCronTrigger } = await import('../../functions/modules/notifications.js');
+
+    getAllSubscriptions.mockResolvedValue([
+      {
+        id: 'sub-1',
+        name: 'Sub One',
+        url: 'https://sub.example.com',
+        enabled: true
+      }
+    ]);
+
+    const response = await handleCronTrigger({});
+    const payload = await response.json();
+
+    expect(payload.summary).toMatchObject({
+      total: 1,
+      updated: 1,
+      failed: 0,
+      changes: true
+    });
+    expect(getAllSubscriptions).toHaveBeenCalledTimes(1);
+    expect(get).toHaveBeenCalledWith('worker_settings_v1');
+    expect(get).not.toHaveBeenCalledWith('misub_subscriptions_v1');
+    expect(putAllSubscriptions).toHaveBeenCalledWith([
+      expect.objectContaining({
+        id: 'sub-1',
+        nodeCount: 2,
+        userInfo: {
+          upload: 1,
+          download: 2,
+          total: 10
+        }
+      })
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- make `/cron` prefer `getAllSubscriptions()` when loading subscriptions
- make `/cron` prefer `putAllSubscriptions()` when persisting updates
- add a regression test covering the D1 row-level storage path

## Root cause
`/cron` was still reading and writing subscriptions through the legacy `misub_subscriptions_v1` main-row key.

That works for KV storage, but D1 row-level deployments store subscriptions per row. In that mode, `/api/data` can still read subscriptions through helper APIs while `/cron` sees zero subscriptions and returns success without refreshing traffic or node counts.

## Verification
- `npx vitest run tests/unit/notifications-cron-storage.test.js --passWithNoTests`
- `npm run build`

## Notes
The full Vitest suite still has unrelated pre-existing failures in generator and UI tests, so this PR only claims the targeted regression test plus build verification.