### PR TITLE
[codex] Sync subscription user info during fetch

### DIFF
--- a/functions/modules/subscription/cache-manager.js
+++ b/functions/modules/subscription/cache-manager.js
@@ -4,9 +4,29 @@ import {
     createCacheHeaders
 } from '../../services/node-cache-service.js';
 
-// 简单的内存防抖 Map（用于同一 Worker 实例下的并发控制）
 const refreshDebounce = new Map();
-const DEBOUNCE_TIME = 10000; // 10秒防抖
+const DEBOUNCE_TIME = 10000;
+
+function countCachedNodes(cachedData) {
+    const declaredCount = Number(cachedData?.nodeCount);
+    if (Number.isFinite(declaredCount)) return declaredCount;
+    return String(cachedData?.nodes || '').split('\n').filter(line => line.trim()).length;
+}
+
+function hasUsableCachedNodes(cachedData) {
+    return Boolean(String(cachedData?.nodes || '').trim()) && countCachedNodes(cachedData) > 0;
+}
+
+function populateCachedStats(context, cachedNodeCount, targetMisubsCount) {
+    if (!context) return;
+    context.generationStats = {
+        totalNodes: cachedNodeCount,
+        sourceCount: targetMisubsCount,
+        successCount: cachedNodeCount,
+        failCount: 0,
+        duration: 0
+    };
+}
 
 export async function resolveNodeListWithCache({
     storageAdapter,
@@ -22,51 +42,28 @@ export async function resolveNodeListWithCache({
 
     let combinedNodeList;
     let cacheHeaders = {};
+    const canUseCachedData = cachedData && hasUsableCachedNodes(cachedData);
 
-    if (cacheStatus === 'fresh' && cachedData) {
-        // 缓存新鲜：直接返回（当前策略下不会触发，因为 FRESH_TTL=0）
+    if (cacheStatus === 'fresh' && canUseCachedData) {
+        const cachedNodeCount = countCachedNodes(cachedData);
         combinedNodeList = cachedData.nodes;
-        cacheHeaders = createCacheHeaders('HIT', cachedData.nodeCount);
-
-        // [Stats Export] Populate generation stats from cache for deferred logging
-        if (context) {
-            context.generationStats = {
-                totalNodes: cachedData.nodeCount || 0,
-                sourceCount: targetMisubsCount,
-                successCount: cachedData.nodeCount || 0,
-                failCount: 0,
-                duration: 0
-            };
-        }
-    } else if ((cacheStatus === 'stale' || cacheStatus === 'expired') && cachedData) {
-        // 有缓存：立即返回缓存数据，同时后台刷新确保下次获取最新
+        cacheHeaders = createCacheHeaders('HIT', cachedNodeCount);
+        populateCachedStats(context, cachedNodeCount, targetMisubsCount);
+    } else if ((cacheStatus === 'stale' || cacheStatus === 'expired') && canUseCachedData) {
+        const cachedNodeCount = countCachedNodes(cachedData);
         combinedNodeList = cachedData.nodes;
-        cacheHeaders = createCacheHeaders(`REFRESHING`, cachedData.nodeCount);
+        cacheHeaders = createCacheHeaders('REFRESHING', cachedNodeCount);
 
-        // 内存防抖：如果最近 10 秒内已触发过刷新，则跳过
         const lastRun = refreshDebounce.get(cacheKey);
         if (!lastRun || Date.now() - lastRun > DEBOUNCE_TIME) {
             refreshDebounce.set(cacheKey, Date.now());
-            // 触发后台刷新，确保缓存始终是最新的
             triggerBackgroundRefresh(context, () => refreshNodes(true));
-        } else {
-            // console.debug('[Cache] Skipping background refresh due to debounce');
         }
 
-        // [Stats Export] Populate generation stats from cache for deferred logging
-        if (context) {
-            context.generationStats = {
-                totalNodes: cachedData.nodeCount || 0,
-                sourceCount: targetMisubsCount,
-                successCount: cachedData.nodeCount || 0,
-                failCount: 0,
-                duration: 0
-            };
-        }
+        populateCachedStats(context, cachedNodeCount, targetMisubsCount);
     } else {
-        // 无缓存（首次访问或缓存已过期）：同步获取并缓存
         combinedNodeList = await refreshNodes(false);
-        cacheHeaders = createCacheHeaders('MISS', combinedNodeList.split('\n').filter(l => l.trim()).length);
+        cacheHeaders = createCacheHeaders('MISS', combinedNodeList.split('\n').filter(line => line.trim()).length);
     }
 
     return { combinedNodeList, cacheHeaders, cacheStatus };

--- a/functions/modules/subscription/main-handler.js
+++ b/functions/modules/subscription/main-handler.js
@@ -87,6 +87,37 @@ export function buildManagedConfigUrl(requestUrl) {
     return managedUrl.toString();
 }
 
+function getCurrentRequestUserInfo(context, sub) {
+    const currentInfo = context?.currentSubscriptionRuntimeInfo || {};
+    const runtimeInfo = currentInfo[sub?.id] || currentInfo[sub?.url];
+    return runtimeInfo?.userInfo || sub?.userInfo || null;
+}
+
+function buildUserInfoHeaderFromSubscriptions(context, subscriptions) {
+    const totalUserInfo = subscriptions.reduce((acc, sub) => {
+        const userInfo = sub?.enabled ? getCurrentRequestUserInfo(context, sub) : null;
+        if (!userInfo) return acc;
+
+        return {
+            upload: (acc.upload || 0) + (userInfo.upload || 0),
+            download: (acc.download || 0) + (userInfo.download || 0),
+            total: (acc.total || 0) + (userInfo.total || 0),
+            expire: Math.max(acc.expire || 0, userInfo.expire || 0)
+        };
+    }, { upload: 0, download: 0, total: 0, expire: 0 });
+
+    const safeUserInfo = {
+        upload: isFinite(totalUserInfo.upload) ? totalUserInfo.upload : 0,
+        download: isFinite(totalUserInfo.download) ? totalUserInfo.download : 0,
+        total: isFinite(totalUserInfo.total) ? totalUserInfo.total : 0,
+        expire: isFinite(totalUserInfo.expire) ? totalUserInfo.expire : 0
+    };
+
+    return safeUserInfo.total > 0
+        ? `upload=${safeUserInfo.upload}; download=${safeUserInfo.download}; total=${safeUserInfo.total}; expire=${safeUserInfo.expire}`
+        : null;
+}
+
 export function resolveTemplateUrl(mode, value, fallbackUrl = '') {
     const normalizedMode = typeof mode === 'string' ? mode.trim().toLowerCase() : '';
     const normalizedValue = typeof value === 'string' ? value.trim() : '';
@@ -541,14 +572,20 @@ export async function handleMisubRequest(context) {
     // 1. If 'nodes' format requested, return plain text nodes (DataSource for external converters)
     if (targetFormat === 'nodes') {
         const contentToReturn = isProfileExpired ? (DEFAULT_EXPIRED_NODE + '\n') : combinedNodeList;
+        const userInfoHeader = buildUserInfoHeaderFromSubscriptions(context, targetMisubs);
+        const nodeHeaders = {
+            "Content-Type": "text/plain; charset=utf-8",
+            'Cache-Control': 'no-store, no-cache',
+            'X-MiSub-Mode': 'node-export-plain'
+        };
+        if (userInfoHeader) {
+            nodeHeaders['Subscription-Userinfo'] = userInfoHeader;
+            nodeHeaders['Profile-Update-Interval'] = String(config.UpdateInterval || 24);
+        }
         // [兼容性优化] 第三方转换后端对明文列表的支持通常比 Base64 更好。
         // 同时对于 Cloudflare 而言，明文输出更有利于其边缘节点的流式处理。
         return new Response(contentToReturn, { 
-            headers: { 
-                "Content-Type": "text/plain; charset=utf-8", 
-                'Cache-Control': 'no-store, no-cache',
-                'X-MiSub-Mode': 'node-export-plain'
-            } 
+            headers: nodeHeaders
         });
     }
 
@@ -737,28 +774,7 @@ export async function handleMisubRequest(context) {
 
     if (shouldUseBuiltin) {
         try {
-            const totalUserInfo = targetMisubs.reduce((acc, sub) => {
-                if (sub.enabled && sub.userInfo) {
-                    return {
-                        upload: (acc.upload || 0) + (sub.userInfo.upload || 0),
-                        download: (acc.download || 0) + (sub.userInfo.download || 0),
-                        total: (acc.total || 0) + (sub.userInfo.total || 0),
-                        expire: Math.max(acc.expire || 0, sub.userInfo.expire || 0)
-                    };
-                }
-                return acc;
-            }, { upload: 0, download: 0, total: 0, expire: 0 });
-
-            const safeUserInfo = {
-                upload: isFinite(totalUserInfo.upload) ? totalUserInfo.upload : 0,
-                download: isFinite(totalUserInfo.download) ? totalUserInfo.download : 0,
-                total: isFinite(totalUserInfo.total) ? totalUserInfo.total : 0,
-                expire: isFinite(totalUserInfo.expire) ? totalUserInfo.expire : 0
-            };
-
-            const userInfoHeader = safeUserInfo.total > 0 
-                ? `upload=${safeUserInfo.upload}; download=${safeUserInfo.download}; total=${safeUserInfo.total}; expire=${safeUserInfo.expire}`
-                : null;
+            const userInfoHeader = buildUserInfoHeaderFromSubscriptions(context, targetMisubs);
 
             let { content: finalContent, contentType, headers: resultHeaders } = await ProcessorService.renderOutput({
                 targetFormat,
@@ -841,6 +857,11 @@ export async function handleMisubRequest(context) {
     }
 
     const base64Headers = { "Content-Type": "text/plain; charset=utf-8", 'Cache-Control': 'no-store, no-cache' };
+    const userInfoHeader = buildUserInfoHeaderFromSubscriptions(context, targetMisubs);
+    if (userInfoHeader) {
+        base64Headers['Subscription-Userinfo'] = userInfoHeader;
+        base64Headers['Profile-Update-Interval'] = String(config.UpdateInterval || 24);
+    }
     Object.entries(cacheHeaders).forEach(([key, value]) => {
         base64Headers[key] = value;
     });

--- a/functions/services/subscription-service.js
+++ b/functions/services/subscription-service.js
@@ -161,6 +161,14 @@ function scheduleSubscriptionRuntimeInfoUpdate(context, storage, sub, runtimeInf
     });
 }
 
+function recordCurrentRequestRuntimeInfo(context, sub, runtimeInfo) {
+    const key = sub?.id || sub?.url;
+    if (!context || !key) return;
+
+    context.currentSubscriptionRuntimeInfo = context.currentSubscriptionRuntimeInfo || {};
+    context.currentSubscriptionRuntimeInfo[key] = runtimeInfo;
+}
+
 /**
  * 带重试的订阅获取函数（支持网络错误和 HTTP 状态码重试）
  * @param {string} url - 请求 URL
@@ -466,10 +474,12 @@ const prependGroupName = profilePrefixSettings?.prependGroupName ?? false;
 
             if (realNodes.length > 0) {
                 const userInfo = parseSubscriptionUserInfoHeader(response.headers.get('subscription-userinfo'));
-                scheduleSubscriptionRuntimeInfoUpdate(context, storage, sub, {
+                const runtimeInfo = {
                     nodeCount: realNodes.length,
                     userInfo
-                });
+                };
+                recordCurrentRequestRuntimeInfo(context, sub, runtimeInfo);
+                scheduleSubscriptionRuntimeInfoUpdate(context, storage, sub, runtimeInfo);
             }
 
             // 判断是否启用订阅前缀（智能重命名启用时跳过）

--- a/functions/services/subscription-service.js
+++ b/functions/services/subscription-service.js
@@ -47,6 +47,21 @@ export function isRealProxyNode(node) {
     return REAL_PROXY_PROTOCOLS.some(protocol => trimmed.startsWith(protocol));
 }
 
+export function parseSubscriptionUserInfoHeader(header) {
+    if (typeof header !== 'string' || !header.trim()) return null;
+
+    const info = {};
+    header.split(';').forEach(part => {
+        const [rawKey, rawValue] = part.trim().split('=');
+        const key = rawKey?.trim();
+        const value = rawValue?.trim();
+        if (!key || value === undefined || value === '') return;
+        info[key] = /^\d+$/.test(value) ? Number(value) : value;
+    });
+
+    return Object.keys(info).length > 0 ? info : null;
+}
+
 /**
  * 构建单机场订阅源的保护性缓存 key
  */
@@ -94,6 +109,56 @@ async function writeSubscriptionNodeCache(storage, sub, nodes) {
         console.warn('[SubscriptionCache] Failed to write cache:', error);
         return false;
     }
+}
+
+async function writeSubscriptionRuntimeInfo(storage, sub, { nodeCount, userInfo } = {}) {
+    if (!storage || !sub?.id) return false;
+
+    try {
+        const applyUpdate = current => {
+            if (!current) return current;
+            return {
+                ...current,
+                nodeCount: Number.isFinite(nodeCount) ? nodeCount : current.nodeCount,
+                ...(userInfo ? { userInfo } : {}),
+                lastError: null,
+                lastUpdate: new Date().toISOString()
+            };
+        };
+
+        if (typeof storage.updateSubscriptionById === 'function') {
+            return Boolean(await storage.updateSubscriptionById(sub.id, applyUpdate));
+        }
+
+        if (typeof storage.get === 'function' && typeof storage.put === 'function') {
+            const all = await storage.get('misub_subscriptions_v1');
+            if (!Array.isArray(all)) return false;
+            const index = all.findIndex(item => item?.id === sub.id);
+            if (index === -1) return false;
+            all[index] = applyUpdate(all[index]);
+            await storage.put('misub_subscriptions_v1', all);
+            return true;
+        }
+    } catch (error) {
+        console.warn('[SubscriptionRuntimeInfo] Failed to write subscription info:', error);
+    }
+
+    return false;
+}
+
+function scheduleSubscriptionRuntimeInfoUpdate(context, storage, sub, runtimeInfo) {
+    const promise = writeSubscriptionRuntimeInfo(storage, sub, runtimeInfo);
+
+    if (context && typeof context.waitUntil === 'function') {
+        context.waitUntil(promise.catch(error => {
+            console.warn('[SubscriptionRuntimeInfo] Async update failed:', error);
+        }));
+        return;
+    }
+
+    promise.catch(error => {
+        console.warn('[SubscriptionRuntimeInfo] Async update failed:', error);
+    });
 }
 
 /**
@@ -397,6 +462,14 @@ const prependGroupName = profilePrefixSettings?.prependGroupName ?? false;
 
             if (cacheEnabled) {
                 await writeSubscriptionNodeCache(storage, sub, realNodes);
+            }
+
+            if (realNodes.length > 0) {
+                const userInfo = parseSubscriptionUserInfoHeader(response.headers.get('subscription-userinfo'));
+                scheduleSubscriptionRuntimeInfoUpdate(context, storage, sub, {
+                    nodeCount: realNodes.length,
+                    userInfo
+                });
             }
 
             // 判断是否启用订阅前缀（智能重命名启用时跳过）

--- a/tests/unit/cache-manager.test.js
+++ b/tests/unit/cache-manager.test.js
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from 'vitest';
+import { resolveNodeListWithCache } from '../../functions/modules/subscription/cache-manager.js';
+
+function createStorage(cachedData) {
+    return {
+        get: vi.fn().mockResolvedValue(cachedData)
+    };
+}
+
+describe('resolveNodeListWithCache', () => {
+    it('returns a fresh non-empty cache without refreshing', async () => {
+        const refreshNodes = vi.fn().mockResolvedValue('trojan://password@1.2.3.5:443#JP-01');
+        const context = {};
+
+        const result = await resolveNodeListWithCache({
+            storageAdapter: createStorage({
+                nodes: 'trojan://password@1.2.3.4:443#HK-01',
+                timestamp: Date.now(),
+                nodeCount: 1,
+                sources: ['airport']
+            }),
+            cacheKey: 'node_cache_token_test',
+            forceRefresh: false,
+            refreshNodes,
+            context,
+            targetMisubsCount: 1
+        });
+
+        expect(result.combinedNodeList).toBe('trojan://password@1.2.3.4:443#HK-01');
+        expect(result.cacheHeaders['X-Cache-Status']).toBe('HIT');
+        expect(result.cacheHeaders['X-Node-Count']).toBe('1');
+        expect(refreshNodes).not.toHaveBeenCalled();
+        expect(context.generationStats.totalNodes).toBe(1);
+    });
+
+    it('refreshes synchronously when a fresh cache contains zero nodes', async () => {
+        const refreshNodes = vi.fn().mockResolvedValue('trojan://password@1.2.3.4:443#HK-01');
+
+        const result = await resolveNodeListWithCache({
+            storageAdapter: createStorage({
+                nodes: '',
+                timestamp: Date.now(),
+                nodeCount: 0,
+                sources: ['airport']
+            }),
+            cacheKey: 'node_cache_token_test',
+            forceRefresh: false,
+            refreshNodes,
+            context: {},
+            targetMisubsCount: 1
+        });
+
+        expect(result.combinedNodeList).toBe('trojan://password@1.2.3.4:443#HK-01');
+        expect(result.cacheHeaders['X-Cache-Status']).toBe('MISS');
+        expect(result.cacheHeaders['X-Node-Count']).toBe('1');
+        expect(refreshNodes).toHaveBeenCalledTimes(1);
+        expect(refreshNodes).toHaveBeenCalledWith(false);
+    });
+});

--- a/tests/unit/misub-request-regression.test.js
+++ b/tests/unit/misub-request-regression.test.js
@@ -124,4 +124,41 @@ describe('handleMisubRequest regression coverage', () => {
         expect(dataSourceText).toContain('trojan://pass@example.com:443#');
         expect(dataSourceText).not.toMatch(/^[A-Za-z0-9+/=]+$/);
     });
+
+    it('returns current fetch traffic header on the first builtin response', async () => {
+        const subscriptions = [{
+            id: 'sub-a',
+            name: '鏈哄満A',
+            url: 'https://airport.example/sub',
+            enabled: true,
+            userInfo: null
+        }];
+        const adapter = createStorageAdapter({
+            settings: { mytoken: 'stable-token', enableFlagEmoji: false, enableTrafficNode: false },
+            subscriptions
+        });
+        createAdapter.mockReturnValue(adapter);
+        vi.stubGlobal('fetch', vi.fn(async () => new Response('trojan://pass@example.com:443#HK', {
+            status: 200,
+            headers: {
+                'subscription-userinfo': 'upload=10; download=20; total=1000; expire=2000'
+            }
+        })));
+
+        const waitUntilPromises = [];
+        const { handleMisubRequest } = await import('../../functions/modules/subscription/main-handler.js');
+        const response = await handleMisubRequest({
+            request: new Request('https://misub.example/stable-token?target=clash&refresh=1&builtin=true', {
+                headers: { 'User-Agent': 'ClashMeta' }
+            }),
+            env: {},
+            waitUntil: promise => waitUntilPromises.push(promise)
+        });
+        const text = await response.text();
+
+        expect(response.status).toBe(200);
+        expect(text).toContain('proxies:');
+        expect(response.headers.get('Subscription-Userinfo')).toBe('upload=10; download=20; total=1000; expire=2000');
+        expect(waitUntilPromises.length).toBeGreaterThan(0);
+    });
 });

--- a/tests/unit/subscription-protective-cache.test.js
+++ b/tests/unit/subscription-protective-cache.test.js
@@ -128,12 +128,13 @@ describe('subscription protective node cache', () => {
                 'subscription-userinfo': 'upload=1; download=2; total=100; expire=200'
             }
         })));
+        const context = {
+            storage,
+            waitUntil: promise => waitUntilPromises.push(promise)
+        };
 
         const result = await generateCombinedNodeList(
-            {
-                storage,
-                waitUntil: promise => waitUntilPromises.push(promise)
-            },
+            context,
             { enableAccessLog: false, enableFlagEmoji: false },
             'ClashMeta',
             [sub],
@@ -144,6 +145,12 @@ describe('subscription protective node cache', () => {
 
         expect(result.trim()).toBe('trojan://pass@example.com:443#HK');
         expect(waitUntilPromises).toHaveLength(1);
+        expect(context.currentSubscriptionRuntimeInfo[sub.id].userInfo).toEqual({
+            upload: 1,
+            download: 2,
+            total: 100,
+            expire: 200
+        });
 
         await Promise.all(waitUntilPromises);
 

--- a/tests/unit/subscription-protective-cache.test.js
+++ b/tests/unit/subscription-protective-cache.test.js
@@ -2,7 +2,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
     buildSubscriptionNodeCacheKey,
     generateCombinedNodeList,
-    isRealProxyNode
+    isRealProxyNode,
+    parseSubscriptionUserInfoHeader
 } from '../../functions/services/subscription-service.js';
 
 function createMemoryStorage(initial = {}) {
@@ -34,6 +35,16 @@ describe('subscription protective node cache', () => {
         expect(isRealProxyNode('127.0.0.1:8080#剩余流量')).toBe(false);
         expect(isRealProxyNode('到期时间：2099-01-01')).toBe(false);
         expect(isRealProxyNode('')).toBe(false);
+    });
+
+    it('解析机场返回的 subscription-userinfo 响应头', () => {
+        expect(parseSubscriptionUserInfoHeader('upload=1; download=2; total=100; expire=200')).toEqual({
+            upload: 1,
+            download: 2,
+            total: 100,
+            expire: 200
+        });
+        expect(parseSubscriptionUserInfoHeader('')).toBeNull();
     });
 
     it('enableNodeCache 开启时，成功拉取真实节点后写入单机场缓存', async () => {
@@ -103,6 +114,49 @@ describe('subscription protective node cache', () => {
         const cache = await storage.get(cacheKey);
         expect(result.trim()).toBe('trojan://cached@example.com:443#Cached');
         expect(cache.nodes).toEqual(['trojan://cached@example.com:443#Cached']);
+    });
+
+    it('外部拉取成功时，异步同步节点数和流量到前端订阅数据', async () => {
+        const sub = { id: 'sub-a', name: '机场A', url: 'https://example.com/sub', enabled: true, enableNodeCache: true };
+        const storage = createMemoryStorage({
+            misub_subscriptions_v1: [{ ...sub, nodeCount: 0, userInfo: null }]
+        });
+        const waitUntilPromises = [];
+        vi.stubGlobal('fetch', vi.fn(async () => new Response('trojan://pass@example.com:443#HK', {
+            status: 200,
+            headers: {
+                'subscription-userinfo': 'upload=1; download=2; total=100; expire=200'
+            }
+        })));
+
+        const result = await generateCombinedNodeList(
+            {
+                storage,
+                waitUntil: promise => waitUntilPromises.push(promise)
+            },
+            { enableAccessLog: false, enableFlagEmoji: false },
+            'ClashMeta',
+            [sub],
+            '',
+            { enableSubscriptions: false },
+            false
+        );
+
+        expect(result.trim()).toBe('trojan://pass@example.com:443#HK');
+        expect(waitUntilPromises).toHaveLength(1);
+
+        await Promise.all(waitUntilPromises);
+
+        const [updatedSub] = await storage.get('misub_subscriptions_v1');
+        expect(updatedSub.nodeCount).toBe(1);
+        expect(updatedSub.userInfo).toEqual({
+            upload: 1,
+            download: 2,
+            total: 100,
+            expire: 200
+        });
+        expect(updatedSub.lastError).toBeNull();
+        expect(typeof updatedSub.lastUpdate).toBe('string');
     });
 
     it('enableNodeCache 关闭时，拉取失败不使用旧缓存', async () => {


### PR DESCRIPTION
## Summary

Improve external subscription fetch behavior for providers that require a short manual authorization window.

This keeps subscription fetches responsive while ensuring runtime subscription information is not delayed unnecessarily when MiSub already performed a synchronous upstream fetch.

## Changes

- Sync node count and `subscription-userinfo` back to stored subscription data after successful external fetches.
- Avoid treating a fresh node cache with zero nodes as usable; zero-node caches now trigger a synchronous refresh instead of blocking retries during the fresh-cache window.
- Return `Subscription-Userinfo` from the current upstream fetch immediately in the same client response when available, while still updating stored frontend data asynchronously via `waitUntil`.
- Preserve the existing fast path for non-empty fresh caches and stale-cache background refresh behavior.

## Validation

- `npm run test:run -- tests/unit/misub-request-regression.test.js tests/unit/subscription-protective-cache.test.js tests/unit/cache-manager.test.js tests/unit/node-cache-service.test.js`

## Notes

This does not force every client request to re-fetch upstream traffic data. Current upstream traffic is returned immediately only when the request already performs a synchronous upstream fetch; cache-hit responses continue to use stored user info.