### PR TITLE
Fix ACL4SSR rule provider path mapping

### DIFF
--- a/functions/modules/subscription/template-renderers/render-clash.js
+++ b/functions/modules/subscription/template-renderers/render-clash.js
@@ -20,7 +20,32 @@ function filterAutoSelectMembers(group) {
 }
 
 const ACL4SSR_ROOT_PROVIDER_FILES = new Set([
-    'proxygfwlist'
+    'apple',
+    'banad',
+    'baneasylist',
+    'baneasylistchina',
+    'baneasyprivacy',
+    'banprogramad',
+    'chinacompanyip',
+    'chinadomain',
+    'chinaip',
+    'chinaipv6',
+    'chinamedia',
+    'download',
+    'localareanetwork',
+    'mjj',
+    'proxylite',
+    'proxygfwlist',
+    'proxymedia',
+    'unban'
+]);
+
+const ACL4SSR_IPCIDR_PROVIDER_FILES = new Set([
+    'amazonip',
+    'chinacompanyip',
+    'chinaip',
+    'chinaipv6',
+    'netflixip'
 ]);
 
 function toClashRuleProviderUrl(sourceUrl) {
@@ -50,6 +75,16 @@ function toClashRuleProviderUrl(sourceUrl) {
     } catch {
         return sourceUrl;
     }
+}
+
+function getRuleProviderBehavior(providerUrl) {
+    try {
+        const fileName = new URL(providerUrl).pathname.split('/').pop()?.replace(/\.(yaml|yml|list|txt|conf)$/i, '') || '';
+        if (ACL4SSR_IPCIDR_PROVIDER_FILES.has(fileName.toLowerCase())) return 'ipcidr';
+    } catch {
+        // ignore invalid provider url shapes and keep default behavior
+    }
+    return 'classical';
 }
 
 function mapRule(rule, ruleProviderMap) {
@@ -93,7 +128,7 @@ export function renderClashFromTemplateModel(model) {
         ruleProviderMap.set(providerUrl, providerName);
         ruleProviders[providerName] = {
             type: 'http',
-            behavior: 'classical',
+            behavior: getRuleProviderBehavior(providerUrl),
             url: providerUrl,
             path: `./ruleset/${providerName}.yaml`,
             interval: 86400

--- a/tests/unit/template-pipeline.test.js
+++ b/tests/unit/template-pipeline.test.js
@@ -357,7 +357,7 @@ custom_proxy_group=TestGroup`;
         expect(providerUrls.every(url => !String(url).endsWith('.list'))).toBe(true);
     });
 
-    it('should map ACL4SSR root Clash list rules to existing provider ruleset urls', () => {
+    it('should map ACL4SSR Clash list rules to existing provider urls', () => {
         const rendered = renderClashFromIniTemplate(`
 [custom]
 ruleset=📲 电报消息,https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Telegram.list
@@ -374,5 +374,37 @@ custom_proxy_group=🚀 节点选择\`select\`[]DIRECT\`.*
 
         expect(providerUrls).toContain('https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Providers/Ruleset/Telegram.yaml');
         expect(providerUrls).toContain('https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Providers/ProxyGFWlist.yaml');
+    });
+
+    it('should keep ACL4SSR full root providers readable without expanding rules', () => {
+        const rendered = renderClashFromIniTemplate(`
+[custom]
+ruleset=LAN,https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/LocalAreaNetwork.list
+ruleset=AD,https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/BanAD.list
+ruleset=Media,https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/ProxyMedia.list
+ruleset=GoogleFCM,https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Ruleset/GoogleFCM.list
+ruleset=AI,https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Ruleset/AI.list
+ruleset=ChinaIP,https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/ChinaCompanyIp.list
+ruleset=Final,[]FINAL
+custom_proxy_group=Proxy\`select\`[]DIRECT\`.*
+`, {
+            nodeList: 'trojan://password@1.2.3.4:443#HK-01',
+            targetFormat: 'clash'
+        });
+
+        const parsed = yaml.load(rendered);
+        const providers = Object.values(parsed['rule-providers'] || {});
+        const providerUrls = providers.map(provider => provider.url);
+
+        expect(providerUrls).toContain('https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Providers/LocalAreaNetwork.yaml');
+        expect(providerUrls).toContain('https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Providers/BanAD.yaml');
+        expect(providerUrls).toContain('https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Providers/ProxyMedia.yaml');
+        expect(providerUrls).toContain('https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Providers/Ruleset/GoogleFCM.yaml');
+        expect(providerUrls).toContain('https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Providers/Ruleset/AI.yaml');
+
+        const chinaCompanyIpProvider = providers.find(provider => provider.url === 'https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Providers/ChinaCompanyIp.yaml');
+        expect(chinaCompanyIpProvider?.behavior).toBe('ipcidr');
+        expect(providerUrls).not.toContain('https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Providers/Ruleset/BanAD.yaml');
+        expect(providerUrls).not.toContain('https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Providers/Ruleset/LocalAreaNetwork.yaml');
     });
 });


### PR DESCRIPTION
## Summary

Fix ACL4SSR `.list` to Clash `rule-providers` URL mapping in the built-in Clash renderer.

The previous logic only treated `ProxyGFWlist` as an ACL4SSR root provider. Other root-level ACL4SSR lists such as `LocalAreaNetwork.list`, `BanAD.list`, and `ProxyMedia.list` were converted to `Clash/Providers/Ruleset/*.yaml`, which does not exist for those files and causes 404s in Clash/Mihomo.

## Changes

- Expand the static ACL4SSR root provider mapping so root-level provider files are converted to `Clash/Providers/*.yaml`.
- Keep `Clash/Ruleset/*.list` conversion as `Clash/Providers/Ruleset/*.yaml`.
- Mark IP-only provider files such as `ChinaCompanyIp`, `ChinaIp`, `ChinaIpV6`, `AmazonIp`, and `NetflixIP` with `behavior: ipcidr`.
- Add unit coverage for ACL4SSR full-style root providers and Ruleset providers.

## Validation

- `npm run test:run -- tests/unit/template-pipeline.test.js tests/unit/subscription-protective-cache.test.js`
- Rendered `ACL4SSR_Online_Full.ini` locally and confirmed it produces 31 rule providers, no bad `Providers/Ruleset/BanAD.yaml` or `Providers/Ruleset/LocalAreaNetwork.yaml` mappings, and still uses `RULE-SET` without expanding rules.