### PR TITLE
fix(cache): only refresh cache timestamp on successful upstream fetch

### DIFF
--- a/functions/modules/subscription/main-handler.js
+++ b/functions/modules/subscription/main-handler.js
@@ -657,7 +657,12 @@ export async function handleMisubRequest(context) {
         const sourceNames = targetMisubs
             .filter(s => typeof s?.url === 'string' && s.url.startsWith('http'))
             .map(s => s.name || s.url);
-        await setCache(storageAdapter, cacheKey, freshNodes, sourceNames);
+        // 仅在至少一个订阅源真正从远程拉取成功时才刷新缓存时间
+        // 如果没有 HTTP 订阅源（纯手动节点/过期订阅组），则始终写入缓存
+        const stats = context.generationStats;
+        if (!stats?.sourceCount || stats.upstreamSuccessCount > 0) {
+            await setCache(storageAdapter, cacheKey, freshNodes, sourceNames);
+        }
         return freshNodes;
     };
 

--- a/functions/services/subscription-service.js
+++ b/functions/services/subscription-service.js
@@ -402,6 +402,7 @@ const prependGroupName = profilePrefixSettings?.prependGroupName ?? false;
 
     const httpSubs = misubs.filter(sub => sub && sub.url && sub.url.toLowerCase().startsWith('http'));
     const limiter = createConcurrencyLimiter(FETCH_CONFIG.CONCURRENCY);
+    let upstreamSuccessCount = 0; // 追踪真正从远程拉取成功的订阅数（不含 per-sub 缓存回退）
 
     /**
      * 获取单个订阅内容
@@ -488,6 +489,7 @@ const prependGroupName = profilePrefixSettings?.prependGroupName ?? false;
             }
 
             if (realNodes.length > 0) {
+                upstreamSuccessCount++;
                 const userInfo = parseSubscriptionUserInfoHeader(response.headers.get('subscription-userinfo'));
                 const runtimeInfo = {
                     nodeCount: realNodes.length,
@@ -598,6 +600,7 @@ const prependGroupName = profilePrefixSettings?.prependGroupName ?? false;
                 sourceCount: httpSubs.length,
                 successCount,
                 failCount,
+                upstreamSuccessCount,
                 duration: endTime - (context.startTime || Date.now())
             };
         }

--- a/tests/unit/node-cache-service.test.js
+++ b/tests/unit/node-cache-service.test.js
@@ -36,6 +36,7 @@ describe('node-cache-service', () => {
 
         const storage = createStorage({
             stale: { nodes: 'a', timestamp: now - (FRESH_TTL + 1000), nodeCount: 1, sources: [] },
+            // STALE_TTL == MAX_AGE 时，STALE_TTL + 1000 已超过 MAX_AGE，直接变 miss
             expired: { nodes: 'b', timestamp: now - (STALE_TTL + 1000), nodeCount: 2, sources: [] },
             miss: { nodes: 'c', timestamp: now - (MAX_AGE + 1000), nodeCount: 3, sources: [] }
         });
@@ -44,7 +45,8 @@ describe('node-cache-service', () => {
         expect(stale.status).toBe('stale');
 
         const expired = await getCache(storage, 'expired');
-        expect(expired.status).toBe('expired');
+        // 当 STALE_TTL == MAX_AGE 时，expired 状态不可达，直接变为 miss
+        expect(expired.status).toBe(STALE_TTL < MAX_AGE ? 'expired' : 'miss');
 
         const miss = await getCache(storage, 'miss');
         expect(miss.status).toBe('miss');


### PR DESCRIPTION
## 问题

`refreshNodes()` 在 `generateCombinedNodeList()` 执行完毕后会**无条件**调用 `setCache()`，即使所有上游订阅拉取都失败了（例如机场开启了订阅保护）。这会导致缓存时间戳被空数据/旧数据刷新，掩盖了拉取失败的事实，阻止了系统及时重试。

### 复现场景

1. 1:00 成功拉取节点 → 缓存写入，`timestamp = 1:00`
2. 13:00 缓存 KV TTL 过期，全局缓存被自动删除
3. 15:00 再次拉取，拉取失败，所有 HTTP 请求返回非 200
4. `setCache()` 仍被调用，写入空数据并设 `timestamp = 5:00`
5. 15:30 再次请求 → 缓存 age = 30 分钟 → 落入 `stale` 窗口 → 返回空缓存而非触发同步重新拉取

**预期行为**：15:00 拉取失败时不应刷新缓存时间戳，15:30 请求应为 `miss` 状态并触发同步拉取。

## 修复方案

1. 在 `generateCombinedNodeList()` 中新增 `upstreamSuccessCount` 计数器，仅在远程 HTTP 请求真正返回 200 且解析出有效代理节点时才递增（不含 per-subscription 缓存回退）
2. 在 `refreshNodes()` 中将 `setCache()` 改为条件调用：
   - 存在 HTTP 订阅源时：仅 `upstreamSuccessCount > 0` 才写缓存
   - 无 HTTP 订阅源时（纯手动节点/过期订阅组）：始终写缓存
3. 修复 `node-cache-service.test.js` 中的失败测试：当 `STALE_TTL == MAX_AGE` 时 `expired` 状态不可达

## 改动文件

| 文件 | 改动 |
|------|------|
| `functions/services/subscription-service.js` | 新增 `upstreamSuccessCount` 追踪，并暴露至 `generationStats` |
| `functions/modules/subscription/main-handler.js` | `setCache()` 改为条件调用 |
| `tests/unit/node-cache-service.test.js` 