### PR TITLE
fix(quanx): rename VLESS flow parameter to vless-flow for Quantumult X compatibility

### DIFF
--- a/functions/modules/subscription/builtin-quanx-generator.js
+++ b/functions/modules/subscription/builtin-quanx-generator.js
@@ -165,7 +165,7 @@ function buildQxLine(proxy) {
             if (realityOpts['short-id']) extraParts.push(`reality-hex-shortid=${realityOpts['short-id']}`);
         }
 
-        if (proxy.flow) extraParts.push(`flow=${proxy.flow}`);
+        if (proxy.flow) extraParts.push(`vless-flow=${proxy.flow}`);
         appendQxTlsParams(extraParts, proxy);
         return `vless=${server}:${port}, password=${uuid}${extraParts.length > 0 ? `, ${extraParts.join(', ')}` : ''}, tag=${name}`;
     }

--- a/functions/modules/subscription/template-renderers/render-quanx.js
+++ b/functions/modules/subscription/template-renderers/render-quanx.js
@@ -89,7 +89,7 @@ function buildProxyLine(proxy) {
             if (realityOpts['public-key']) extras.push(`reality-base64-pubkey=${realityOpts['public-key']}`);
             if (realityOpts['short-id']) extras.push(`reality-hex-shortid=${realityOpts['short-id']}`);
         }
-        if (proxy.flow) extras.push(`flow=${proxy.flow}`);
+        if (proxy.flow) extras.push(`vless-flow=${proxy.flow}`);
         if (proxy['skip-cert-verify'] === true || proxy.skipCertVerify === true) extras.push('tls-verification=false');
         return `vless=${server}:${port}, password=${proxy.uuid || ''}${extras.length ? `, ${extras.join(', ')}` : ''}, tag=${name}`;
     }

--- a/src/utils/protocols/quantumultx-parser.js
+++ b/src/utils/protocols/quantumultx-parser.js
@@ -334,6 +334,7 @@ function parseQuantumultXVless(line) {
                     }
                     break;
                 case 'flow':
+                case 'vless-flow':
                     urlParams.push(`flow=${encodeURIComponent(value)}`);
                     break;
             }

--- a/tests/unit/builtin-quanx-generator.test.js
+++ b/tests/unit/builtin-quanx-generator.test.js
@@ -204,7 +204,7 @@ describe('Quantumult X 内置生成器', () => {
 
         expect(generated).toContain('vless=tls.example.com:443, password=11111111-1111-4111-8111-111111111111, method=none, obfs=over-tls, obfs-host=tls.example.com, tag=🌍 VLESS-TLS');
         expect(generated).toContain('vless=reality.example.com:443, password=22222222-2222-4222-8222-222222222222, method=none, obfs=over-tls, obfs-host=addons.mozilla.org, reality-base64-pubkey=testpublickey, reality-hex-shortid=abcdef, tag=🌍 VLESS-Reality');
-        expect(generated).toContain('vless=vision.example.com:443, password=33333333-3333-4333-8333-333333333333, method=none, obfs=over-tls, obfs-host=vision.example.com, flow=xtls-rprx-vision, tag=🌍 VLESS-Vision');
+        expect(generated).toContain('vless=vision.example.com:443, password=33333333-3333-4333-8333-333333333333, method=none, obfs=over-tls, obfs-host=vision.example.com, vless-flow=xtls-rprx-vision, tag=🌍 VLESS-Vision');
         expect(generated).not.toContain('over-tls=true');
         expect(generated).not.toContain('tls-host=vision.example.com');
 

--- a/tests/unit/template-pipeline.test.js
+++ b/tests/unit/template-pipeline.test.js
@@ -314,7 +314,7 @@ custom_proxy_group=TestGroup`, {
 
         expect(quanxRendered).toContain('vless=tls.example.com:443, password=11111111-1111-4111-8111-111111111111, method=none, obfs=over-tls, obfs-host=tls.example.com, tag=🌍 VLESS-TLS');
         expect(quanxRendered).toContain('vless=reality.example.com:443, password=22222222-2222-4222-8222-222222222222, method=none, obfs=over-tls, obfs-host=addons.mozilla.org, reality-base64-pubkey=testpublickey, reality-hex-shortid=abcdef, tag=🌍 VLESS-Reality');
-        expect(quanxRendered).toContain('vless=vision.example.com:443, password=33333333-3333-4333-8333-333333333333, method=none, obfs=over-tls, obfs-host=vision.example.com, flow=xtls-rprx-vision, tag=🌍 VLESS-Vision');
+        expect(quanxRendered).toContain('vless=vision.example.com:443, password=33333333-3333-4333-8333-333333333333, method=none, obfs=over-tls, obfs-host=vision.example.com, vless-flow=xtls-rprx-vision, tag=🌍 VLESS-Vision');
         expect(quanxRendered).not.toContain('over-tls=true');
         expect(quanxRendered).not.toContain('tls-host=vision.example.com');
     });


### PR DESCRIPTION
This PR renames VLESS 'flow' parameter to 'vless-flow' to match Quantumult X specifications, and updates the parser to recognize both 'flow' and 'vless-flow' parameters to ensure proper round-trip conversion.