### PR TITLE
Fix modal backdrop drag dismissal / 修复弹窗拖拽误关闭

### DIFF
--- a/src/components/forms/Modal.vue
+++ b/src/components/forms/Modal.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { ref, watch, nextTick, onUnmounted, computed } from 'vue';
 import { useI18n } from '@/i18n/index.js';
+import { useBackdropDismiss } from '@/composables/useBackdropDismiss.js';
 
 const props = defineProps({
   show: Boolean,
@@ -116,12 +117,17 @@ const handleConfirm = async () => {
     emit('update:show', false);
   }
 };
+
+const {
+  handleBackdropPointerDown,
+  handleBackdropClick
+} = useBackdropDismiss(() => emit('update:show', false));
 </script>
 
 <template>
   <Transition name="modal-fade">
     <div v-if="show" class="fixed inset-0 bg-black/60 backdrop-blur-xs z-50 flex items-center justify-center p-4"
-      @click="emit('update:show', false)" role="dialog" aria-modal="true" :aria-labelledby="titleId">
+      @pointerdown.capture="handleBackdropPointerDown" @click="handleBackdropClick" role="dialog" aria-modal="true" :aria-labelledby="titleId">
       <Transition name="modal-inner">
         <div v-if="show"
           ref="modalPanelRef"

--- a/src/components/modals/NodePreview/NodePreviewContainer.vue
+++ b/src/components/modals/NodePreview/NodePreviewContainer.vue
@@ -17,6 +17,7 @@ import EmptyState from './EmptyState.vue';
 
 // Composables
 import { useNodePreview } from '@/composables/useNodePreview.js';
+import { useBackdropDismiss } from '@/composables/useBackdropDismiss.js';
 
 const props = defineProps({
   show: Boolean,
@@ -64,6 +65,11 @@ const handleClose = () => {
   emit('update:show', false);
 };
 
+const {
+  handleBackdropPointerDown,
+  handleBackdropClick
+} = useBackdropDismiss(handleClose);
+
 // 自动加载数据
 onMounted(() => {
   if (props.show) {
@@ -78,7 +84,8 @@ onMounted(() => {
     v-if="show"
     class="fixed inset-0 z-50 overflow-y-auto"
     :class="{ 'bg-black bg-opacity-50': show }"
-    @click.self="handleClose"
+    @pointerdown.capture="handleBackdropPointerDown"
+    @click.self="handleBackdropClick"
   >
     <div class="flex min-h-full items-center justify-center p-4 text-center sm:p-0">
       <div class="relative transform overflow-hidden misub-radius-md bg-white dark:bg-gray-800 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-6xl">

--- a/src/components/public/QRCodeOverlay.vue
+++ b/src/components/public/QRCodeOverlay.vue
@@ -1,4 +1,6 @@
 <script setup>
+import { useBackdropDismiss } from '../../composables/useBackdropDismiss.js';
+
 const props = defineProps({
   profile: {
     type: Object,
@@ -11,6 +13,11 @@ const props = defineProps({
 });
 
 const emit = defineEmits(['close', 'download', 'register-canvas']);
+
+const {
+  handleBackdropPointerDown,
+  handleBackdropClick
+} = useBackdropDismiss(() => emit('close'));
 </script>
 
 <template>
@@ -18,7 +25,8 @@ const emit = defineEmits(['close', 'download', 'register-canvas']);
     <Transition name="qr-overlay">
       <div
         v-if="isExpanded"
-        @click.self="emit('close')"
+        @pointerdown.capture="handleBackdropPointerDown"
+        @click.self="handleBackdropClick"
         class="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-[100]"
       >
         <div class="relative bg-white dark:bg-gray-800 misub-radius-lg p-8 shadow-2xl max-w-sm w-full mx-4 transform transition-all border border-gray-100 dark:border-gray-700"

--- a/src/components/shared/FormModal.vue
+++ b/src/components/shared/FormModal.vue
@@ -6,6 +6,7 @@
 <script setup>
 import { ref, watch, nextTick, computed } from 'vue';
 import { t } from '../../i18n/index.js';
+import { useBackdropDismiss } from '../../composables/useBackdropDismiss.js';
 
 const props = defineProps({
   show: {
@@ -131,11 +132,13 @@ const handleClose = () => {
 };
 
 // 处理遮罩点击
-const handleMaskClick = () => {
-  if (props.maskClosable && !props.disabled && !props.loading) {
-    handleClose();
-  }
-};
+const {
+  handleBackdropPointerDown: handleMaskPointerDown,
+  handleBackdropClick: handleMaskClick
+} = useBackdropDismiss(
+  handleClose,
+  () => props.maskClosable && !props.disabled && !props.loading
+);
 
 // 处理确认
 const handleConfirm = () => {
@@ -195,6 +198,7 @@ defineExpose({
       <div
         class="flex min-h-full items-center justify-center p-4 text-center sm:p-0"
         :class="{ 'bg-black/60 backdrop-blur-sm': show }"
+        @pointerdown.capture="handleMaskPointerDown"
         @click="handleMaskClick"
       >
         <!-- 模态框 -->

--- a/src/composables/useBackdropDismiss.js
+++ b/src/composables/useBackdropDismiss.js
@@ -1,0 +1,21 @@
+export function useBackdropDismiss(onDismiss, canDismiss = () => true) {
+  let pointerDownStartedOnBackdrop = false;
+
+  const handleBackdropPointerDown = (event) => {
+    pointerDownStartedOnBackdrop = event.target === event.currentTarget;
+  };
+
+  const handleBackdropClick = (event) => {
+    const shouldDismiss = pointerDownStartedOnBackdrop && event.target === event.currentTarget;
+    pointerDownStartedOnBackdrop = false;
+
+    if (shouldDismiss && canDismiss()) {
+      onDismiss(event);
+    }
+  };
+
+  return {
+    handleBackdropPointerDown,
+    handleBackdropClick
+  };
+}

--- a/tests/unit/modal-backdrop-dismiss.test.js
+++ b/tests/unit/modal-backdrop-dismiss.test.js
@@ -1,0 +1,103 @@
+import { nextTick } from 'vue';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import FormModal from '../../src/components/shared/FormModal.vue';
+import Modal from '../../src/components/forms/Modal.vue';
+import QRCodeOverlay from '../../src/components/public/QRCodeOverlay.vue';
+import { useBackdropDismiss } from '../../src/composables/useBackdropDismiss.js';
+
+const dispatchBubbled = async (element, type) => {
+  element.dispatchEvent(new Event(type, { bubbles: true, cancelable: true }));
+  await nextTick();
+};
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('modal backdrop dismiss behavior', () => {
+  it('only dismisses after pointerdown starts on the backdrop', () => {
+    const dismiss = vi.fn();
+    const backdrop = document.createElement('div');
+    const panel = document.createElement('div');
+    backdrop.append(panel);
+
+    const { handleBackdropPointerDown, handleBackdropClick } = useBackdropDismiss(dismiss);
+
+    handleBackdropPointerDown({ target: panel, currentTarget: backdrop });
+    handleBackdropClick({ target: backdrop, currentTarget: backdrop });
+    expect(dismiss).not.toHaveBeenCalled();
+
+    handleBackdropPointerDown({ target: backdrop, currentTarget: backdrop });
+    handleBackdropClick({ target: backdrop, currentTarget: backdrop });
+    expect(dismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the shared form modal open when dragging from inside to the backdrop', async () => {
+    const wrapper = mount(FormModal, {
+      props: { show: true, title: 'Edit' },
+      attachTo: document.body,
+      slots: { default: '<input data-testid="field" />' }
+    });
+
+    await nextTick();
+    const backdrop = document.body.querySelector('.flex.min-h-full');
+    const input = document.body.querySelector('[data-testid="field"]');
+
+    await dispatchBubbled(input, 'pointerdown');
+    await dispatchBubbled(backdrop, 'click');
+    expect(wrapper.emitted('update:show')).toBeUndefined();
+
+    await dispatchBubbled(backdrop, 'pointerdown');
+    await dispatchBubbled(backdrop, 'click');
+    expect(wrapper.emitted('update:show')).toEqual([[false]]);
+
+    wrapper.unmount();
+  });
+
+  it('keeps the generic modal open when dragging from inside to the backdrop', async () => {
+    const wrapper = mount(Modal, {
+      props: { show: true },
+      attachTo: document.body,
+      slots: { body: '<input data-testid="field" />' }
+    });
+
+    await nextTick();
+    const backdrop = document.body.querySelector('[role="dialog"]');
+    const input = document.body.querySelector('[data-testid="field"]');
+
+    await dispatchBubbled(input, 'pointerdown');
+    await dispatchBubbled(backdrop, 'click');
+    expect(wrapper.emitted('update:show')).toBeUndefined();
+
+    await dispatchBubbled(backdrop, 'pointerdown');
+    await dispatchBubbled(backdrop, 'click');
+    expect(wrapper.emitted('update:show')).toEqual([[false]]);
+
+    wrapper.unmount();
+  });
+
+  it('keeps the QR overlay open when dragging from inside to the backdrop', async () => {
+    const wrapper = mount(QRCodeOverlay, {
+      props: {
+        isExpanded: true,
+        profile: { id: 'profile-1', name: 'Demo' }
+      },
+      attachTo: document.body
+    });
+
+    await nextTick();
+    const backdrop = document.body.querySelector('.fixed.inset-0');
+    const panel = backdrop.querySelector('.relative');
+
+    await dispatchBubbled(panel, 'pointerdown');
+    await dispatchBubbled(backdrop, 'click');
+    expect(wrapper.emitted('close')).toBeUndefined();
+
+    await dispatchBubbled(backdrop, 'pointerdown');
+    await dispatchBubbled(backdrop, 'click');
+    expect(wrapper.emitted('close')).toHaveLength(1);
+
+    wrapper.unmount();
+  });
+});


### PR DESCRIPTION
## Summary

Prevent modal backdrops from closing when a pointer drag starts inside the dialog and ends on the backdrop.
Apply shared backdrop-dismiss handling to the shared form modal, generic modal, node preview, and QR overlay.
Add regression tests for internal drag behavior and normal backdrop clicks.

## 总结

修复弹窗内按下拖拽到遮罩后松手会误关闭的问题。
将共享表单弹窗、通用弹窗、节点预览和二维码浮层接入统一遮罩关闭判断。
新增回归测试覆盖内部拖拽不关闭和直接点击遮罩关闭。

## Verification

- `npm test -- tests/unit/modal-backdrop-dismiss.test.js`
- `npm run build`

## 验证

- `npm test -- tests/unit/modal-backdrop-dismiss.test.js`
- `npm run build`
