### PR TITLE
feat(subscription): 仅在开启保护性缓存节点时添加时间戳绕过上游 CDN/Cloudflare 缓存

### DIFF
--- a/functions/modules/subscription/node-fetcher.js
+++ b/functions/modules/subscription/node-fetcher.js
@@ -19,7 +19,7 @@ import {
  * @param {boolean} plusAsSpace - 是否将名称中的 + 视为空格
  * @returns {Promise<Object>} 节点获取结果
  */
-export async function fetchSubscriptionNodes(url, subscriptionName, userAgent, customUserAgent = null, debug = false, excludeRules = '', fetchProxy = null, skipCertVerify = false, plusAsSpace = false) {
+export async function fetchSubscriptionNodes(url, subscriptionName, userAgent, customUserAgent = null, debug = false, excludeRules = '', fetchProxy = null, skipCertVerify = false, plusAsSpace = false, enableNodeCache = false) {
     // 自动检测调试 Token
     const shouldDebug = debug || (url && url.includes('b0b422857bb46aba65da8234c84f38c6'));
 
@@ -30,6 +30,18 @@ export async function fetchSubscriptionNodes(url, subscriptionName, userAgent, c
 
         // 当配置了 fetchProxy 时，使用代理拉取订阅
         let requestUrl = url;
+        
+        // 只有开启保护性缓存节点时才加时间戳绕过强缓存 (如 Cloudflare Edge Cache)
+        if (enableNodeCache) {
+            try {
+                const parsedUrl = new URL(requestUrl);
+                parsedUrl.searchParams.set('_t', Date.now().toString());
+                requestUrl = parsedUrl.toString();
+            } catch (e) {
+                requestUrl += (requestUrl.includes('?') ? '&' : '?') + '_t=' + Date.now();
+            }
+        }
+
         if (fetchProxy && typeof fetchProxy === 'string' && fetchProxy.trim()) {
             requestUrl = buildFetchProxyUrl(fetchProxy, url, effectiveUserAgent);
         }

--- a/functions/modules/subscription/profile-handler.js
+++ b/functions/modules/subscription/profile-handler.js
@@ -160,7 +160,7 @@ export async function handleProfileMode(request, env, profileId, userAgent, appl
 
     // 并行获取HTTP订阅节点
     const subscriptionResults = await Promise.all(
-        targetSubscriptions.map(sub => fetchSubscriptionNodes(sub.url, sub.name, userAgent, sub.customUserAgent, false, sub.exclude, sub.fetchProxy, skipCertVerify, Boolean(sub?.plusAsSpace)))
+        targetSubscriptions.map(sub => fetchSubscriptionNodes(sub.url, sub.name, userAgent, sub.customUserAgent, false, sub.exclude, sub.fetchProxy, skipCertVerify, Boolean(sub?.plusAsSpace), sub?.enableNodeCache === true))
     );
 
     // 合并所有结果

--- a/functions/modules/subscription/single-subscription.js
+++ b/functions/modules/subscription/single-subscription.js
@@ -54,7 +54,7 @@ export async function handleSingleSubscriptionMode(request, env, subscriptionId,
     }
 
     // HTTP订阅：获取节点
-    const result = await fetchSubscriptionNodes(subscription.url, subscription.name, userAgent, subscription.customUserAgent, false, subscription.exclude, subscription.fetchProxy, skipCertVerify, Boolean(subscription?.plusAsSpace));
+    const result = await fetchSubscriptionNodes(subscription.url, subscription.name, userAgent, subscription.customUserAgent, false, subscription.exclude, subscription.fetchProxy, skipCertVerify, Boolean(subscription?.plusAsSpace), subscription?.enableNodeCache === true);
 
     return {
         success: true,

--- a/functions/services/subscription-service.js
+++ b/functions/services/subscription-service.js
@@ -436,6 +436,18 @@ const prependGroupName = profilePrefixSettings?.prependGroupName ?? false;
             // [Fetch Proxy] 获取单点订阅专属拉取代理前缀
             assertPublicNetworkUrl(sub.url);
             let requestUrl = sub.url;
+            
+            // 只有开启保护性缓存节点时才加时间戳绕过强缓存 (如 Cloudflare Edge Cache)
+            if (cacheEnabled) {
+                try {
+                    const parsedUrl = new URL(requestUrl);
+                    parsedUrl.searchParams.set('_t', Date.now().toString());
+                    requestUrl = parsedUrl.toString();
+                } catch (e) {
+                    requestUrl += (requestUrl.includes('?') ? '&' : '?') + '_t=' + Date.now();
+                }
+            }
+
             if (sub.fetchProxy && typeof sub.fetchProxy === 'string' && sub.fetchProxy.trim()) {
                 requestUrl = buildFetchProxyUrl(sub.fetchProxy, sub.url, processedUserAgent);
             }


### PR DESCRIPTION
### 更改原因 (Why this change)

在一些机场开启了“订阅保护授权”等强安全限制的场景下，若用户关闭或失效了授权后重新开启，机场端（或其前面的 Cloudflare Edge CDN）大概率会有一定时间的强缓存保护。
此时即便用户在机场网站重新开启了授权，由于客户端请求的 URL 完全一致，短时间内仍会直接拉取到被缓存的失效结果，导致在客户端/后端看来订阅依旧是“失效/空”的状态。

为了解决这个问题，可以通过为拉取请求 URL 附加时间戳参数 `_t=Date.now()` 的方式强行破坏上游 Edge Cache。
但是，无脑添加时间戳会使得机场所有的边缘缓存彻底失效，增加机场服务器的压力，也可能导致一些严格限流的机场将此判定为异常流量。

因此，本 PR 将该逻辑修改为：**仅当用户开启了“保护性缓存节点”这一高级选项时，才在拉取 URL 后附加时间戳进行缓存穿透。** 这样既能在需要拉取保护性缓存、规避零节点清空时穿透缓存拉取最新结果，又不会在日常普通拉取时对机场服务器带来额外开销。

### 更改内容 (What changes)

1. 在 `functions/modules/subscription/node-fetcher.js` 中的 `fetchSubscriptionNodes` 方法中新增 `enableNodeCache` 参数，并在此参数为 `true` 时才在 URL 尾部添加 `_t` 时间戳。
2. 修改 `profile-handler.js` 与 `single-subscription.js` 中对 `fetchSubscriptionNodes` 的调用，透传各订阅的 `enableNodeCache` 参数。
3. 修改 `subscription-service.js` 中的 `fetchSingleSubscription`，将后台更新订阅时的 `_t` 时间戳生成逻辑修改为仅在 `cacheEnabled` 时生效。
