### PR TITLE
feat: support handshake-timeout parameter for Hysteria2 nodes

### DIFF
--- a/functions/utils/url-to-clash.js
+++ b/functions/utils/url-to-clash.js
@@ -652,6 +652,12 @@ function parseHysteria2Url(url) {
             proxy['skip-cert-verify'] = true;
         }
 
+        // [Hysteria2] handshake timeout
+        const handshakeTimeout = params.get('handshake-timeout');
+        if (handshakeTimeout) {
+            proxy["handshake-timeout"] = parseInt(handshakeTimeout, 10);
+        }
+
         // Obfs
         if (params.get('obfs')) {
             proxy.obfs = params.get('obfs');
@@ -690,6 +696,7 @@ function parseHysteria2Url(url) {
         if (params.get('dp')) {
             proxy['dialer-proxy'] = params.get('dp');
         }
+
 
 return proxy;
 } catch (e) {


### PR DESCRIPTION
## 变更内容

在 `functions/utils/url-to-clash.js` 的 `parseHysteria2Url()` 函数中新增 `handshake-timeout` 查询参数解析。

### 改动

```js
// [Hysteria2] handshake timeout
const handshakeTimeout = params.get('handshake-timeout');
if (handshakeTimeout) {
    proxy["handshake-timeout"] = parseInt(handshakeTimeout, 10);
}
```

### 使用方式

手动节点 URL 中添加查询参数：
```
hysteria2://password@server:port/?handshake-timeout=30#节点名
```

生成的 Clash/Mihomo YAML 输出：
```yaml
proxies:
  - name: HY2-Realm
    type: hysteria2
    server: realm.hy2.io
    port: 443
    password: xxx
    handshake-timeout: 30
    realm-opts:
      enable: true
      ...
```

### 相关 Issue

Closes #422

### 背景

Hysteria2 Realm 模式在 mihomo 中存在 `context deadline exceeded` 问题，mihomo 已新增 `handshake-timeout` 参数解决。MiSub 需要支持该参数以确保 Realm 模式用户导出的订阅配置包含正确的超时设置。