### PR TITLE
fix(rename): preserve regex capture groups

### DIFF
--- a/functions/utils/operator-runner.js
+++ b/functions/utils/operator-runner.js
@@ -112,7 +112,7 @@ function opRename(nodes, params) {
                     return rule;
                 });
 
-                const newName = NodeUtils.applyRegexRename(r.name, processedRules);
+                const newName = NodeUtils.applyRegexRename(r.name, processedRules, r);
                 if (newName !== r.name) {
                     return {
                         ...r,

--- a/src/components/features/Operators/components/RenameEditor.vue
+++ b/src/components/features/Operators/components/RenameEditor.vue
@@ -59,7 +59,7 @@ const applyPresetTemplate = (tpl) => {
 
 // 预设正则
 const presetRegexRules = [
-  { nameKey: 'operators.regexPresetRegionProviderLine', pattern: '\\[(.*?)\\]-(.*?)-(.*?)', replacement: '' },
+  { nameKey: 'operators.regexPresetRegionProviderLine', pattern: '\\[(.*?)\\]-(.*?)-(.*)$', replacement: '' },
   { nameKey: 'operators.regexPresetExtractSuffix', pattern: '(.*?) -(.*?)$', replacement: '$1' },
 ];
 

--- a/tests/unit/operator-runner.test.js
+++ b/tests/unit/operator-runner.test.js
@@ -57,6 +57,71 @@ describe('operator runner', () => {
     }
   });
 
+  it('passes regex capture groups to a template in the same rename operator', async () => {
+    const urls = [
+      `ss://YWVzLTEyOC1nY206cGFzcw@example.com:8388#${encodeURIComponent('[香港]-机场A-线路B')}`
+    ];
+    const result = await runOperatorChain(urls, [
+      {
+        type: 'rename',
+        params: {
+          regex: {
+            enabled: true,
+            rules: [
+              {
+                pattern: '\\[(.*?)\\]-(.*?)-(.*)$',
+                replacement: '',
+                flags: 'gi'
+              }
+            ]
+          },
+          template: {
+            enabled: true,
+            template: '{g1}|{g2}|{g3}',
+            indexScope: 'global'
+          }
+        }
+      }
+    ]);
+
+    expect(decodeURIComponent(result[0])).toContain('#香港|机场A|线路B');
+  });
+
+  it('preserves regex capture groups across sequential rename operators', async () => {
+    const urls = [
+      `ss://YWVzLTEyOC1nY206cGFzcw@example.com:8388#${encodeURIComponent('[香港]-机场A-线路B')}`
+    ];
+    const result = await runOperatorChain(urls, [
+      {
+        type: 'rename',
+        params: {
+          regex: {
+            enabled: true,
+            rules: [
+              {
+                pattern: '\\[(.*?)\\]-(.*?)-(.*)$',
+                replacement: '',
+                flags: 'gi'
+              }
+            ]
+          }
+        }
+      },
+      {
+        type: 'rename',
+        params: {
+          template: {
+            enabled: true,
+            template: '{g1}|{g2}|{g3}',
+            indexScope: 'global'
+          }
+        }
+      }
+    ]);
+
+    expect(decodeURIComponent(result[0])).toContain('#香港|机场A|线路B');
+  });
+
   it('sorts nodes by custom group metadata', async () => {
     const urls = [
       'ss://YWVzLTEyOC1nY206cGFzcw@us.example.com:8388#USNode',


### PR DESCRIPTION
## Summary
- preserve regex capture groups on node records during rename operators
- make the region/provider/line preset capture the complete final group
- cover same-operator and sequential-operator template rendering

## Testing
- `npm run test:run` (103 files, 519 tests passed)
- `npm run build`