### PR TITLE
fix: harden Clash DNS and filter loopback pseudo-nodes

### DIFF
--- a/functions/modules/subscription/builtin-clash-generator.js
+++ b/functions/modules/subscription/builtin-clash-generator.js
@@ -7,6 +7,7 @@
 import { urlsToClashProxies } from '../../utils/url-to-clash.js';
 import { getUniqueName } from './name-utils.js';
 import { isMetaCore } from './user-agent-utils.js';
+import { resolveSafeDnsConfig } from './safe-dns.js';
 import {
     POLICY_GROUPS,
     RULE_SETS,
@@ -195,58 +196,8 @@ export function generateBuiltinClashConfig(nodeList, options = {}) {
             proxyGroups = relayConfig.proxyGroups;
         }
 
-        // 基础配置
-        const defaultDns = {
-            'enable': true,
-            'ipv6': true,
-            'enhanced-mode': 'fake-ip',
-            'fake-ip-range': '198.18.0.1/16',
-            'fake-ip-filter': [
-                'geosite:private',
-                'geosite:category-ntp'
-            ],
-            'use-hosts': false,
-            'use-system-hosts': false,
-            'nameserver': [
-                'https://1.1.1.1/dns-query',
-                'https://8.8.8.8/dns-query'
-            ],
-            'proxy-server-nameserver': [
-                'https://223.5.5.5/dns-query',
-                'https://223.6.6.6/dns-query'
-            ],
-            'nameserver-policy': {
-                'geosite:cn': [
-                    'https://223.5.5.5/dns-query',
-                    'https://223.6.6.6/dns-query'
-                ]
-            },
-            'respect-rules': true
-        };
-
-        let dnsConfig = defaultDns;
-        const customDnsRaw = options.customDnsOverride || '';
-        if (customDnsRaw.trim()) {
-            try {
-                let parsed;
-                const trimmed = customDnsRaw.trim();
-                if (/^\{/.test(trimmed)) {
-                    parsed = JSON.parse(trimmed);
-                } else {
-                    parsed = yaml.load(trimmed);
-                }
-                if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-                    // 如果解析结果包含 dns 顶层键，取 dns 的值
-                    if (parsed.dns && typeof parsed.dns === 'object' && !Array.isArray(parsed.dns)) {
-                        dnsConfig = parsed.dns;
-                    } else {
-                        dnsConfig = parsed;
-                    }
-                }
-            } catch {
-                // 格式错误，保持使用默认 DNS
-            }
-        }
+        // 基础配置：安全默认值，不再依赖 KV 覆盖才能避免 DNS 递归。
+        const dnsConfig = resolveSafeDnsConfig(options.customDnsOverride || '');
 
         const config = {
             'mixed-port': 7890,

--- a/functions/modules/subscription/builtin-clash-generator.js
+++ b/functions/modules/subscription/builtin-clash-generator.js
@@ -7,7 +7,7 @@
 import { urlsToClashProxies } from '../../utils/url-to-clash.js';
 import { getUniqueName } from './name-utils.js';
 import { isMetaCore } from './user-agent-utils.js';
-import { resolveSafeDnsConfig } from './safe-dns.js';
+import { DNS_PROXY_GROUP, resolveSafeDnsConfig } from './safe-dns.js';
 import {
     POLICY_GROUPS,
     RULE_SETS,
@@ -197,14 +197,19 @@ export function generateBuiltinClashConfig(nodeList, options = {}) {
         }
 
         // 基础配置：安全默认值，不再依赖 KV 覆盖才能避免 DNS 递归。
-        const dnsConfig = resolveSafeDnsConfig(options.customDnsOverride || '');
+        const dnsConfig = resolveSafeDnsConfig(options.customDnsOverride || '', {
+            mode: options.dnsMode,
+            proxyGroup: DNS_PROXY_GROUP
+        });
 
         const config = {
             'mixed-port': 7890,
-            'allow-lan': true,
+            'allow-lan': false,
+            'bind-address': '127.0.0.1',
+            'ipv6': false,
             'mode': 'rule',
             'log-level': 'info',
-            'external-controller': ':9090',
+            'external-controller': '127.0.0.1:9090',
 
             'dns': dnsConfig,
 

--- a/functions/modules/subscription/builtin-rules-provider.js
+++ b/functions/modules/subscription/builtin-rules-provider.js
@@ -1,5 +1,5 @@
 import { groupNodeLinesByRegion } from './region-groups.js';
-import { DNS_PROXY_GROUP } from './safe-dns.js';
+import { DNS_PROXY_GROUP, SINGBOX_CN_RULE_SET } from './safe-dns.js';
 
 /**
  * 策略组标准名称常量
@@ -321,6 +321,10 @@ export const REMOTE_SOURCES = {
     'geoip-cn': {
         name: 'China IP (GeoIP)',
         singbox: `${SING_GEOIP_BASE}/geoip-cn.srs`
+    },
+    [SINGBOX_CN_RULE_SET]: {
+        name: 'China Domains (GeoSite)',
+        singbox: `${SING_GEOSITE_BASE}/geosite-cn.srs`
     }
 };
 
@@ -485,4 +489,8 @@ export function getRemoteProviderDefinitions(format, ruleLines) {
     });
 
     return providers;
+}
+
+export function getSingboxDnsRuleSet() {
+    return getRemoteProviderDefinitions('singbox', [{ type: 'rule_set', tag: SINGBOX_CN_RULE_SET }])[SINGBOX_CN_RULE_SET];
 }

--- a/functions/modules/subscription/builtin-rules-provider.js
+++ b/functions/modules/subscription/builtin-rules-provider.js
@@ -1,4 +1,5 @@
 import { groupNodeLinesByRegion } from './region-groups.js';
+import { DNS_PROXY_GROUP } from './safe-dns.js';
 
 /**
  * 策略组标准名称常量
@@ -8,6 +9,52 @@ export const DEFAULT_RELAY_GROUP = '🌍 总出口';
 export const AUTO_SELECT_GROUP = '♻️ 自动选择';
 export const FALLBACK_GROUP = '🔯 故障转移';
 export const MANUAL_SELECT_GROUP = '👋 手动切换';
+
+export const AI_SERVICE_RULES = Object.freeze([
+    { id: 'openai', name: 'OpenAI', domains: ['openai.com', 'chatgpt.com', 'oaistatic.com', 'oaiusercontent.com', 'auth0.openai.com'] },
+    { id: 'claude', name: 'Claude', domains: ['anthropic.com', 'claude.ai', 'claude.com', 'claudeusercontent.com', 'anthropicusercontent.com'] },
+    { id: 'gemini', name: 'Gemini', domains: ['gemini.google.com', 'aistudio.google.com', 'generativelanguage.googleapis.com', 'ai.google.dev', 'makersuite.google.com'] },
+    { id: 'copilot', name: 'Copilot', domains: ['copilot.microsoft.com', 'githubcopilot.com', 'api.githubcopilot.com'] },
+    { id: 'grok', name: 'Grok', domains: ['x.ai', 'grok.com', 'grok.x.com'] },
+    { id: 'perplexity', name: 'Perplexity', domains: ['perplexity.ai', 'pplx.ai'] },
+    { id: 'mistral', name: 'Mistral', domains: ['mistral.ai'] },
+    { id: 'deepseek', name: 'DeepSeek', domains: ['deepseek.com', 'chat.deepseek.com', 'api.deepseek.com'] },
+    { id: 'ai-platforms', name: 'AI 平台', domains: ['poe.com', 'character.ai', 'huggingface.co', 'replicate.com', 'openrouter.ai', 'groq.com', 'cohere.com'] }
+]);
+
+export const AI_DOMAIN_RULE_LINES = AI_SERVICE_RULES.flatMap(service =>
+    service.domains.map(domain => `DOMAIN-SUFFIX,${domain},🤖 ${service.name}`)
+);
+
+const AI_AUTO_GROUP = '🤖 AI 自动';
+const AI_FALLBACK_GROUP = '🤖 AI 故障转移';
+
+function dnsProxyGroup(proxyNames) {
+    return {
+        name: DNS_PROXY_GROUP,
+        type: 'url-test',
+        proxies: proxyNames.length > 0 ? proxyNames : ['REJECT'],
+        hidden: true,
+        options: { url: 'http://www.gstatic.com/generate_204', interval: 300, tolerance: 50 }
+    };
+}
+
+function aiPolicyGroups(proxyNames, regionNames, { relay = false } = {}) {
+    const nodeCandidates = proxyNames.length > 0 ? proxyNames : ['REJECT'];
+    const candidates = [AI_AUTO_GROUP, AI_FALLBACK_GROUP, ...regionNames, MANUAL_SELECT_GROUP];
+    if (relay) candidates.push('🔗 链式代理', '🚀 常用节点');
+
+    return [
+        { name: AI_AUTO_GROUP, type: 'url-test', proxies: nodeCandidates, hidden: true, options: { url: 'http://www.gstatic.com/generate_204', interval: 300, tolerance: 50 } },
+        { name: AI_FALLBACK_GROUP, type: 'fallback', proxies: nodeCandidates, hidden: true, options: { url: 'http://www.gstatic.com/generate_204', interval: 300, tolerance: 50 } },
+        { name: '🤖 智能 AI', type: 'select', proxies: candidates },
+        ...AI_SERVICE_RULES.map(service => ({
+            name: `🤖 ${service.name}`,
+            type: 'select',
+            proxies: candidates
+        }))
+    ];
+}
 
 /**
  * 自动生成地区策略组（通用中间格式）
@@ -34,6 +81,7 @@ export function pruneProxyGroups(proxyGroups, proxies) {
         AUTO_SELECT_GROUP,
         FALLBACK_GROUP,
         MANUAL_SELECT_GROUP,
+        DNS_PROXY_GROUP,
         ...['DIRECT', 'REJECT', 'REJECT-DROP', 'ANY'] // 各平台通用保留字
     ]);
 
@@ -59,9 +107,10 @@ export function pruneProxyGroups(proxyGroups, proxies) {
         });
 
         // 兜底逻辑
+        const failClosed = String(group.name || '').startsWith('🤖') || group.name === DNS_PROXY_GROUP;
         return {
             ...group,
-            proxies: newProxies.length > 0 ? newProxies : ['DIRECT']
+            proxies: newProxies.length > 0 ? newProxies : [failClosed ? 'REJECT' : 'DIRECT']
         };
     });
 }
@@ -108,10 +157,12 @@ export const POLICY_GROUPS = {
     BASE: (proxies, options = {}) => {
         const proxyNames = proxies.map(p => p.tag || p.name);
         return [
+            dnsProxyGroup(proxyNames),
             { name: DEFAULT_SELECT_GROUP, type: 'select', proxies: [AUTO_SELECT_GROUP, FALLBACK_GROUP, MANUAL_SELECT_GROUP, 'DIRECT'] },
             { name: AUTO_SELECT_GROUP, type: 'url-test', proxies: proxyNames },
             { name: FALLBACK_GROUP, type: 'fallback', proxies: proxyNames },
-            { name: MANUAL_SELECT_GROUP, type: 'select', proxies: proxyNames }
+            { name: MANUAL_SELECT_GROUP, type: 'select', proxies: proxyNames },
+            ...aiPolicyGroups(proxyNames, [])
         ];
     },
     // 标准配置：全能型
@@ -120,12 +171,13 @@ export const POLICY_GROUPS = {
         const { regionSelectGroups, regionSupportGroups, regionNames } = _generateRegionGroups(proxies, options);
         
         return [
+            dnsProxyGroup(proxyNames),
             { name: DEFAULT_SELECT_GROUP, type: 'select', proxies: [AUTO_SELECT_GROUP, FALLBACK_GROUP, MANUAL_SELECT_GROUP, ...regionNames, 'DIRECT'] },
             { name: AUTO_SELECT_GROUP, type: 'url-test', proxies: proxyNames },
             { name: FALLBACK_GROUP, type: 'fallback', proxies: proxyNames },
             { name: MANUAL_SELECT_GROUP, type: 'select', proxies: proxyNames },
             ...regionSelectGroups,
-            { name: '🤖 智能 AI', type: 'select', proxies: ['🇺🇸 美国节点', '🇸🇬 狮城节点', '🇯🇵 日本节点', AUTO_SELECT_GROUP, MANUAL_SELECT_GROUP, 'DIRECT'] },
+            ...aiPolicyGroups(proxyNames, regionNames),
             { name: '🎬 视频广告', type: 'select', proxies: ['REJECT', 'DIRECT'] },
             { name: '🎥 流媒体', type: 'select', proxies: ['🇸🇬 狮城节点', '🇭🇰 香港节点', '🇹🇼 台湾节点', '🇯🇵 日本节点', AUTO_SELECT_GROUP, MANUAL_SELECT_GROUP, 'DIRECT'] },
             { name: '🍎 Apple', type: 'select', proxies: ['DIRECT', AUTO_SELECT_GROUP, MANUAL_SELECT_GROUP] },
@@ -140,13 +192,14 @@ export const POLICY_GROUPS = {
         const { regionSelectGroups, regionSupportGroups, regionNames } = _generateRegionGroups(proxies, options);
         
         return [
+            dnsProxyGroup(proxyNames),
             { name: DEFAULT_SELECT_GROUP, type: 'select', proxies: [AUTO_SELECT_GROUP, FALLBACK_GROUP, MANUAL_SELECT_GROUP, ...regionNames, 'DIRECT'] },
             { name: AUTO_SELECT_GROUP, type: 'url-test', proxies: proxyNames },
             { name: FALLBACK_GROUP, type: 'fallback', proxies: proxyNames },
             { name: MANUAL_SELECT_GROUP, type: 'select', proxies: proxyNames },
             ...regionSelectGroups,
-            // 核心修复：业务组直接引用具体地区组或自动选择组，不引用 DEFAULT_SELECT_GROUP 
-            { name: '🤖 智能 AI', type: 'select', proxies: ['🇺🇸 美国节点', '🇸🇬 狮城节点', '🇯🇵 日本节点', AUTO_SELECT_GROUP, MANUAL_SELECT_GROUP, 'DIRECT'] },
+            // AI 服务始终使用代理候选；无可用节点时由 pruneProxyGroups 保持 REJECT。
+            ...aiPolicyGroups(proxyNames, regionNames),
             { name: '🎬 视频广告', type: 'select', proxies: ['REJECT', 'DIRECT'] },
             { name: '🎥 流媒体', type: 'select', proxies: ['🇸🇬 狮城节点', '🇭🇰 香港节点', '🇹🇼 台湾节点', '🇯🇵 日本节点', AUTO_SELECT_GROUP, MANUAL_SELECT_GROUP, 'DIRECT'] },
             { name: '🍎 Apple', type: 'select', proxies: ['DIRECT', AUTO_SELECT_GROUP, MANUAL_SELECT_GROUP] },
@@ -163,6 +216,7 @@ export const POLICY_GROUPS = {
         const { regionSelectGroups, regionSupportGroups, regionNames } = _generateRegionGroups(proxies, options);
         
         return [
+            dnsProxyGroup(proxyNames),
             { name: DEFAULT_RELAY_GROUP, type: 'select', proxies: ['🔗 链式代理', AUTO_SELECT_GROUP, MANUAL_SELECT_GROUP, '🚀 常用节点', ...regionNames, 'DIRECT'] },
             // 保持 provider 层为通用 select，不在抽象层输出 relay 语义。
             // 否则模板渲染/普通 Clash 路径可能把它转换成 Mihomo 专属 dialer-proxy，导致客户端拉取失败。
@@ -176,7 +230,7 @@ export const POLICY_GROUPS = {
             // 核心修复：链式版的分流也禁止回引 DEFAULT_RELAY_GROUP，统一使用地区组或常用节点
             { name: '🎬 视频广告', type: 'select', proxies: ['REJECT', 'DIRECT'] },
             { name: '🎥 流媒体', type: 'select', proxies: ['🇸🇬 狮城节点', '🇭🇰 香港节点', '🇹🇼 台湾节点', '🇯🇵 日本节点', AUTO_SELECT_GROUP, MANUAL_SELECT_GROUP, 'DIRECT'] },
-            { name: '🤖 智能 AI', type: 'select', proxies: ['🔗 链式代理', '🇺🇸 美国节点', '🇸🇬 狮城节点', '🇯🇵 日本节点', '🚀 常用节点', 'DIRECT'] },
+            ...aiPolicyGroups(proxyNames, regionNames, { relay: true }),
             { name: '🍎 Apple', type: 'select', proxies: ['DIRECT', '🚀 常用节点', AUTO_SELECT_GROUP] },
             { name: 'Ⓜ️ Microsoft', type: 'select', proxies: ['DIRECT', '🚀 常用节点', AUTO_SELECT_GROUP] },
             ...regionSupportGroups
@@ -187,51 +241,86 @@ export const POLICY_GROUPS = {
 /**
  * 远程规则源配置 (对齐各平台最高性能格式)
  */
-const SING_GEOSITE_BASE = 'https://raw.githubusercontent.com/SagerNet/sing-geosite/rule-set';
+export const PINNED_RULE_REVISIONS = Object.freeze({
+    ACL4SSR: '433381ebc4b1de59350fa8bed2a04a888228f801',
+    SING_GEOSITE: '0adeef8a3b9201292f6786ef4de81bcc02e971eb',
+    SING_GEOIP: 'b9c5e675b4d5359d4b47f4434fa7ae77e9991306',
+    BLACKMATRIX: '538b8a79532c44dfbcb8e694d2f43e753c60b157'
+});
+
+const ACL4SSR_BASE = `https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/${PINNED_RULE_REVISIONS.ACL4SSR}`;
+const SING_GEOSITE_BASE = `https://raw.githubusercontent.com/SagerNet/sing-geosite/${PINNED_RULE_REVISIONS.SING_GEOSITE}`;
+const SING_GEOIP_BASE = `https://raw.githubusercontent.com/SagerNet/sing-geoip/${PINNED_RULE_REVISIONS.SING_GEOIP}`;
+
+export function pinRemoteRuleUrl(sourceUrl) {
+    const raw = String(sourceUrl || '').trim();
+    if (!/^https?:\/\//i.test(raw)) return sourceUrl;
+
+    try {
+        const url = new URL(raw);
+        if (!/raw\.githubusercontent\.com$/i.test(url.hostname)) return raw;
+        const parts = url.pathname.split('/').filter(Boolean);
+        if (parts.length < 4) return raw;
+        const key = `${parts[0].toLowerCase()}/${parts[1].toLowerCase()}`;
+        const revisions = {
+            'acl4ssr/acl4ssr': PINNED_RULE_REVISIONS.ACL4SSR,
+            'sagernet/sing-geosite': PINNED_RULE_REVISIONS.SING_GEOSITE,
+            'sagernet/sing-geoip': PINNED_RULE_REVISIONS.SING_GEOIP,
+            'blackmatrix7/ios_rule_script': PINNED_RULE_REVISIONS.BLACKMATRIX
+        };
+        const revision = revisions[key];
+        if (!revision) return raw;
+        parts[2] = revision;
+        url.pathname = `/${parts.join('/')}`;
+        return url.toString();
+    } catch {
+        return raw;
+    }
+}
 
 export const REMOTE_SOURCES = {
     ADS: {
         name: '广告拦截',
-        clash: 'https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Providers/Ruleset/BanAD.yaml',
+        clash: `${ACL4SSR_BASE}/Clash/Providers/BanAD.yaml`,
         singbox: `${SING_GEOSITE_BASE}/geosite-category-ads-all.srs`,
-        surge: 'https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/BanAD.list',
-        quanx: 'https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/BanAD.list'
+        surge: `${ACL4SSR_BASE}/Clash/BanAD.list`,
+        quanx: `${ACL4SSR_BASE}/Clash/BanAD.list`
     },
     STREAM: {
         name: '流媒体',
-        clash: 'https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Providers/Ruleset/Netflix.yaml',
+        clash: `${ACL4SSR_BASE}/Clash/Providers/Ruleset/Netflix.yaml`,
         singbox: `${SING_GEOSITE_BASE}/geosite-netflix.srs`,
-        surge: 'https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Netflix.list'
+        surge: `${ACL4SSR_BASE}/Clash/Netflix.list`
     },
     SOCIAL: {
         name: '社交媒体',
-        clash: 'https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Providers/Ruleset/Telegram.yaml',
+        clash: `${ACL4SSR_BASE}/Clash/Providers/Ruleset/Telegram.yaml`,
         singbox: `${SING_GEOSITE_BASE}/geosite-telegram.srs`,
-        surge: 'https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Telegram.list'
+        surge: `${ACL4SSR_BASE}/Clash/Telegram.list`
     },
     APPLE: {
         name: '苹果服务',
-        clash: 'https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Providers/Ruleset/Apple.yaml',
+        clash: `${ACL4SSR_BASE}/Clash/Providers/Ruleset/Apple.yaml`,
         singbox: `${SING_GEOSITE_BASE}/geosite-apple.srs`,
-        surge: 'https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Apple.list'
+        surge: `${ACL4SSR_BASE}/Clash/Apple.list`
     },
     MICROSOFT: {
         name: '微软服务',
-        clash: 'https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Providers/Ruleset/Microsoft.yaml',
+        clash: `${ACL4SSR_BASE}/Clash/Providers/Ruleset/Microsoft.yaml`,
         singbox: `${SING_GEOSITE_BASE}/geosite-microsoft.srs`,
-        surge: 'https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Microsoft.list',
-        quanx: 'https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Microsoft.list'
+        surge: `${ACL4SSR_BASE}/Clash/Microsoft.list`,
+        quanx: `${ACL4SSR_BASE}/Clash/Microsoft.list`
     },
     AI: {
         name: '智能 AI',
-        clash: 'https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Providers/Ruleset/OpenAi.yaml',
+        clash: `${ACL4SSR_BASE}/Clash/Providers/Ruleset/OpenAi.yaml`,
         singbox: `${SING_GEOSITE_BASE}/geosite-openai.srs`,
-        surge: 'https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Ruleset/OpenAi.list',
-        quanx: 'https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Ruleset/OpenAi.list'
+        surge: `${ACL4SSR_BASE}/Clash/Ruleset/OpenAi.list`,
+        quanx: `${ACL4SSR_BASE}/Clash/Ruleset/OpenAi.list`
     },
     'geoip-cn': {
         name: 'China IP (GeoIP)',
-        singbox: 'https://raw.githubusercontent.com/SagerNet/sing-geoip/rule-set/geoip-cn.srs'
+        singbox: `${SING_GEOIP_BASE}/geoip-cn.srs`
     }
 };
 
@@ -240,6 +329,8 @@ export const REMOTE_SOURCES = {
  */
 export const RULE_SETS = {
     BASE: [
+        ...AI_DOMAIN_RULE_LINES,
+        'RULE-SET,AI,🤖 智能 AI',
         `DOMAIN-SUFFIX,google.com,${DEFAULT_SELECT_GROUP}`,
         `DOMAIN-KEYWORD,google,${DEFAULT_SELECT_GROUP}`,
         `DOMAIN-SUFFIX,github.com,${DEFAULT_SELECT_GROUP}`,
@@ -248,6 +339,7 @@ export const RULE_SETS = {
     ],
     STD: [
         'RULE-SET,ADS,🎬 视频广告',
+        ...AI_DOMAIN_RULE_LINES,
         'RULE-SET,AI,🤖 智能 AI',
         'RULE-SET,STREAM,🎥 流媒体',
         'RULE-SET,APPLE,🍎 Apple',
@@ -260,6 +352,7 @@ export const RULE_SETS = {
     FULL: [
         'RULE-SET,ADS,🎬 视频广告',
         'RULE-SET,SOCIAL,📲 Telegram',
+        ...AI_DOMAIN_RULE_LINES,
         'RULE-SET,AI,🤖 智能 AI',
         'RULE-SET,STREAM,🎥 流媒体',
         'RULE-SET,APPLE,🍎 Apple',
@@ -271,6 +364,7 @@ export const RULE_SETS = {
     ],
     RELAY: [
         'RULE-SET,ADS,🎬 视频广告',
+        ...AI_DOMAIN_RULE_LINES,
         'RULE-SET,AI,🤖 智能 AI',
         'RULE-SET,STREAM,🎥 流媒体',
         'RULE-SET,APPLE,🍎 Apple',
@@ -374,7 +468,7 @@ export function getRemoteProviderDefinitions(format, ruleLines) {
             providers[tag] = {
                 type: 'http',
                 behavior: 'classical',
-                url: source.clash,
+                url: pinRemoteRuleUrl(source.clash),
                 path: `./ruleset/${tag}.yaml`,
                 interval: 86400
             };
@@ -383,8 +477,9 @@ export function getRemoteProviderDefinitions(format, ruleLines) {
                 tag: tag,
                 type: 'remote',
                 format: String(source.singbox || '').toLowerCase().endsWith('.srs') ? 'binary' : 'source',
-                url: source.singbox,
-                download_detour: 'DIRECT'
+                url: pinRemoteRuleUrl(source.singbox),
+                update_interval: '24h',
+                download_detour: DNS_PROXY_GROUP
             };
         }
     });

--- a/functions/modules/subscription/builtin-singbox-generator.js
+++ b/functions/modules/subscription/builtin-singbox-generator.js
@@ -6,8 +6,8 @@
 import { urlToClashProxy, urlsToClashProxies } from '../../utils/url-to-clash.js';
 import { getUniqueName } from './name-utils.js';
 import { groupNodeLinesByRegion } from './region-groups.js';
-import { POLICY_GROUPS, getBuiltinRules, getRemoteProviderDefinitions, DEFAULT_SELECT_GROUP, DEFAULT_RELAY_GROUP, pruneProxyGroups } from './builtin-rules-provider.js';
-import { buildSingboxDnsConfig, DNS_PROXY_GROUP } from './safe-dns.js';
+import { POLICY_GROUPS, getBuiltinRules, getRemoteProviderDefinitions, getSingboxDnsRuleSet, DEFAULT_SELECT_GROUP, DEFAULT_RELAY_GROUP, pruneProxyGroups } from './builtin-rules-provider.js';
+import { buildSingboxDnsConfig, DNS_PROXY_GROUP, SINGBOX_CN_RULE_SET } from './safe-dns.js';
 
 function cleanControlChars(str) {
     if (typeof str !== 'string') return str;
@@ -334,7 +334,10 @@ export function generateBuiltinSingboxConfig(nodeList, options = {}) {
     
     // 提取远程 Rule Set 定义 (Sing-Box 格式)
     const ruleSetsMap = getRemoteProviderDefinitions('singbox', rawRules);
-    const ruleSets = Object.values(ruleSetsMap);
+    const ruleSets = [
+        getSingboxDnsRuleSet(),
+        ...Object.values(ruleSetsMap).filter(ruleSet => ruleSet.tag !== SINGBOX_CN_RULE_SET)
+    ];
 
     // 转换路由规则：将中间对象映射为 Sing-Box 语法
     const routeRules = [

--- a/functions/modules/subscription/builtin-singbox-generator.js
+++ b/functions/modules/subscription/builtin-singbox-generator.js
@@ -7,6 +7,7 @@ import { urlToClashProxy, urlsToClashProxies } from '../../utils/url-to-clash.js
 import { getUniqueName } from './name-utils.js';
 import { groupNodeLinesByRegion } from './region-groups.js';
 import { POLICY_GROUPS, getBuiltinRules, getRemoteProviderDefinitions, DEFAULT_SELECT_GROUP, DEFAULT_RELAY_GROUP, pruneProxyGroups } from './builtin-rules-provider.js';
+import { buildSingboxDnsConfig, DNS_PROXY_GROUP } from './safe-dns.js';
 
 function cleanControlChars(str) {
     if (typeof str !== 'string') return str;
@@ -346,16 +347,14 @@ export function generateBuiltinSingboxConfig(nodeList, options = {}) {
         { domain_suffix: ['cn'], outbound: 'DIRECT' }
     ];
 
+    const dnsConfig = buildSingboxDnsConfig(options.customDnsOverride || '', {
+        mode: options.dnsMode,
+        proxyGroup: DNS_PROXY_GROUP
+    });
+
     const config = {
         log: { level: 'info' },
-        dns: {
-            strategy: 'prefer_ipv4',
-            servers: [
-                { tag: 'dns-ali', type: 'udp', server: '223.5.5.5', server_port: 53, detour: 'DIRECT' },
-                { tag: 'dns-google', type: 'udp', server: '8.8.8.8', server_port: 53, detour: DEFAULT_SELECT_GROUP },
-                { tag: 'doh-cloudflare', type: 'https', server: '1.1.1.1', server_port: 443, path: '/dns-query', detour: DEFAULT_SELECT_GROUP }
-            ]
-        },
+        dns: dnsConfig,
         inbounds: [
             {
                 type: 'tun',
@@ -374,6 +373,7 @@ export function generateBuiltinSingboxConfig(nodeList, options = {}) {
         ],
         route: {
             auto_detect_interface: true,
+            default_domain_resolver: dnsConfig.servers[0]?.tag || 'dns-cn-1',
             final: levelKey === 'RELAY' ? DEFAULT_RELAY_GROUP : DEFAULT_SELECT_GROUP,
             rule_set: ruleSets,
             rules: routeRules

--- a/functions/modules/subscription/builtin-template-registry.js
+++ b/functions/modules/subscription/builtin-template-registry.js
@@ -65,7 +65,7 @@ overwrite_original_rules=true`
         description: '面向常见流媒体和 AI 服务场景的内置模板，保留自动选择、地区组和核心服务分流。',
         content: `[custom]
 ruleset=🤖 AI 服务,https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Ruleset/OpenAi.list
-ruleset=🤖 AI 服务,https://raw.githubusercontent.com/cmliu/ACL4SSR/main/Clash/Claude.list
+ruleset=🤖 AI 服务,https://raw.githubusercontent.com/blackmatrix7/ios_rule_script/538b8a79532c44dfbcb8e694d2f43e753c60b157/rule/Clash/Claude/Claude.list
 ruleset=🤖 AI 服务,[]DOMAIN-SUFFIX,x.ai
 ruleset=🤖 AI 服务,[]DOMAIN-SUFFIX,xai.com
 ruleset=🤖 AI 服务,[]DOMAIN-SUFFIX,grok.com
@@ -145,7 +145,7 @@ overwrite_original_rules=true`
         description: '专为 AI 开发者优化，强化 OpenAI/Claude 路由，增加固定节点漂移保护与纯净度检测引导。',
         content: `[custom]
 ruleset=🤖 AI 核心服务,https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Ruleset/OpenAi.list
-ruleset=🤖 AI 核心服务,https://raw.githubusercontent.com/cmliu/ACL4SSR/main/Clash/Claude.list
+ruleset=🤖 AI 核心服务,https://raw.githubusercontent.com/blackmatrix7/ios_rule_script/538b8a79532c44dfbcb8e694d2f43e753c60b157/rule/Clash/Claude/Claude.list
 ruleset=🌍 国外媒体,https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/ProxyMedia.list
 ruleset=🎯 全球直连,[]GEOIP,CN
 ruleset=🐟 漏网之鱼,[]FINAL

--- a/functions/modules/subscription/main-handler.js
+++ b/functions/modules/subscription/main-handler.js
@@ -410,10 +410,13 @@ export function resolveEffectiveEngine({
 }
 
 export function resolveBuiltinRequestOptions({ searchParams, userAgent = '' } = {}) {
+    const params = searchParams || new URLSearchParams('');
+    const dnsMode = params.get('dns-mode') || params.get('dnsMode') || '';
     return {
         userAgent,
-        searchParams: searchParams || new URLSearchParams(''),
-        hiddifyCompatible: isHiddifyAgent(userAgent)
+        searchParams: params,
+        hiddifyCompatible: isHiddifyAgent(userAgent),
+        dnsMode: dnsMode.toLowerCase() === 'polluted' ? 'polluted' : 'clean'
     };
 }
 
@@ -883,7 +886,8 @@ export async function handleMisubRequest(context) {
                     ruleLevel,
                     regionOverrides: Array.isArray(config.regionOverrides) ? config.regionOverrides : [],
                     isMeta: isMetaCore(userAgentHeader, url.searchParams),
-                    customDnsOverride: config.customDnsOverride || ''
+                    customDnsOverride: config.customDnsOverride || '',
+                    dnsMode: url.searchParams.get('dns-mode') || url.searchParams.get('dnsMode') || config.dnsMode || 'clean'
                 };
                 const rendered = await ProcessorService.renderOutput({
                     targetFormat,
@@ -1022,7 +1026,8 @@ export async function handleMisubRequest(context) {
         ruleLevel: ruleLevel, // 统一后的规则等级
         regionOverrides: Array.isArray(config.regionOverrides) ? config.regionOverrides : [],
         isMeta: isMetaCore(userAgentHeader, url.searchParams),
-        customDnsOverride: config.customDnsOverride || ''
+        customDnsOverride: config.customDnsOverride || '',
+        dnsMode: url.searchParams.get('dns-mode') || url.searchParams.get('dnsMode') || config.dnsMode || 'clean'
     };
 
     const managedConfigUrl = buildManagedConfigUrl(request.url);

--- a/functions/modules/subscription/main-handler.js
+++ b/functions/modules/subscription/main-handler.js
@@ -194,7 +194,7 @@ function countSubscriptionNodes(nodeList, prependedContent = '') {
     const lines = String(nodeList || '')
         .split(/\r?\n/)
         .map(line => line.trim())
-        .filter(Boolean);
+        .filter(line => line && !line.startsWith('#'));
     const prependedLines = String(prependedContent || '')
         .split(/\r?\n/)
         .map(line => line.trim())
@@ -493,7 +493,7 @@ export async function handleMisubRequest(context) {
     let subName = config.FileName;
     let isProfileExpired = false; // Moved declaration here
 
-    const DEFAULT_EXPIRED_NODE = `trojan://00000000-0000-0000-0000-000000000000@127.0.0.1:443#${encodeURIComponent('您的订阅已失效')}`;
+    const DEFAULT_EXPIRED_NODE = '# MiSub: 您的订阅已失效';
 
     let currentProfile = null;
 
@@ -622,13 +622,13 @@ export async function handleMisubRequest(context) {
             }, 0);
             if (totalRemainingBytes > 0) {
                 const fakeNodeName = `流量剩余 ≫ ${formatBytes(totalRemainingBytes)}`;
-                virtualNodes.push(`trojan://00000000-0000-0000-0000-000000000000@127.0.0.1:443#${encodeURIComponent(fakeNodeName)}`);
+                virtualNodes.push(`# MiSub: ${fakeNodeName}`);
             }
 
             const expireText = formatSubscriptionExpireTime(expireTimestamp);
             if (expireText) {
                 const fakeNodeName = `到期时间 ≫ ${expireText}`;
-                virtualNodes.push(`trojan://00000000-0000-0000-0000-000000000001@127.0.0.1:443#${encodeURIComponent(fakeNodeName)}`);
+                virtualNodes.push(`# MiSub: ${fakeNodeName}`);
             }
 
             prependedContentForSubconverter = virtualNodes.join('\n');

--- a/functions/modules/subscription/safe-dns.js
+++ b/functions/modules/subscription/safe-dns.js
@@ -76,6 +76,22 @@ function resolverList(value, fallback) {
     return normalized.length > 0 ? normalized : [...fallback];
 }
 
+function plainResolver(value) {
+    const raw = String(value || '').trim();
+    if (!raw || raw === 'system') return '';
+
+    const candidate = DNS_SCHEME_PATTERN.test(raw) ? raw : `udp://${raw}`;
+    try {
+        const parsed = new URL(candidate);
+        const host = parsed.hostname.replace(/^\[|\]$/g, '');
+        if (!DNS_HOST_PATTERN.test(parsed.hostname)) return '';
+        const formattedHost = host.includes(':') ? `[${host}]` : host;
+        return `udp://${formattedHost}:53`;
+    } catch {
+        return '';
+    }
+}
+
 function policyInput(override) {
     return isObject(override.policy) ? { ...override, ...override.policy } : override;
 }
@@ -85,16 +101,21 @@ export function resolveDnsPolicy(raw, options = {}) {
     const input = policyInput(override);
     const mode = normalizeMode(options.mode || input.mode || input['dns-mode']);
 
+    const foreign = resolverList(
+        input.foreign || input.foreignNameservers || input['foreign-nameserver'] || input.nameserver,
+        DEFAULT_DNS_POLICY.foreign
+    );
+    const plainForeign = mode === DNS_MODES.CLEAN
+        ? foreign.map(plainResolver).filter(Boolean)
+        : foreign;
+
     return {
         mode,
         domestic: resolverList(
             input.domestic || input.domesticNameservers || input['domestic-nameserver'] || input['default-nameserver'],
             DEFAULT_DNS_POLICY.domestic
         ),
-        foreign: resolverList(
-            input.foreign || input.foreignNameservers || input['foreign-nameserver'] || input.nameserver,
-            DEFAULT_DNS_POLICY.foreign
-        ),
+        foreign: plainForeign.length > 0 ? plainForeign : [...DEFAULT_DNS_POLICY.foreign],
         polluted: resolverList(
             input.polluted || input.pollutedNameservers || input['polluted-nameserver'] || input.fallback,
             DEFAULT_DNS_POLICY.polluted

--- a/functions/modules/subscription/safe-dns.js
+++ b/functions/modules/subscription/safe-dns.js
@@ -1,85 +1,232 @@
 import yaml from 'js-yaml';
 
+export const DNS_MODES = Object.freeze({
+    CLEAN: 'clean',
+    POLLUTED: 'polluted'
+});
+
+export const DNS_PROXY_GROUP = '🌐 DNS 出口';
+
+export const DEFAULT_DNS_POLICY = Object.freeze({
+    domestic: ['223.5.5.5', '119.29.29.29'],
+    foreign: ['udp://8.8.8.8:53', 'udp://1.1.1.1:53'],
+    polluted: ['https://8.8.8.8/dns-query', 'https://1.1.1.1/dns-query']
+});
+
+const SAFE_DNS_FIELDS = [
+    'cache-algorithm',
+    'fake-ip-range',
+    'fake-ip-filter-mode',
+    'fake-ip-ttl',
+    'use-hosts',
+    'use-system-hosts'
+];
+
+const DNS_HOST_PATTERN = /^(?:(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,63}|(?:\d{1,3}\.){3}\d{1,3}|\[[0-9a-f:]+\])$/i;
+const DNS_SCHEME_PATTERN = /^(?:udp|tcp|tls|https):\/\//i;
+
+function isObject(value) {
+    return value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function clone(value) {
+    if (Array.isArray(value)) return value.map(clone);
+    if (isObject(value)) return Object.fromEntries(Object.entries(value).map(([key, item]) => [key, clone(item)]));
+    return value;
+}
+
+function parseOverride(raw) {
+    if (isObject(raw)) return raw;
+    if (typeof raw !== 'string' || !raw.trim()) return {};
+
+    try {
+        const parsed = yaml.load(raw.trim());
+        if (!isObject(parsed)) return {};
+        return isObject(parsed.dns) ? parsed.dns : parsed;
+    } catch {
+        return {};
+    }
+}
+
+function normalizeMode(value) {
+    return String(value || '').trim().toLowerCase() === DNS_MODES.POLLUTED
+        ? DNS_MODES.POLLUTED
+        : DNS_MODES.CLEAN;
+}
+
+function resolverHost(value) {
+    const raw = String(value || '').trim();
+    if (!raw || raw.includes('#') || raw === 'system') return raw === 'system' ? raw : '';
+
+    const candidate = DNS_SCHEME_PATTERN.test(raw) ? raw : `udp://${raw}`;
+    try {
+        const parsed = new URL(candidate);
+        const host = parsed.hostname.replace(/^\[|\]$/g, '');
+        if (!DNS_HOST_PATTERN.test(parsed.hostname)) return '';
+        if (host === 'localhost' || host === '::1' || /^127\./.test(host) || /^0\./.test(host)) return '';
+        return raw;
+    } catch {
+        return '';
+    }
+}
+
+function resolverList(value, fallback) {
+    const values = Array.isArray(value) ? value : (typeof value === 'string' ? [value] : []);
+    const normalized = values.map(resolverHost).filter(Boolean);
+    return normalized.length > 0 ? normalized : [...fallback];
+}
+
+function policyInput(override) {
+    return isObject(override.policy) ? { ...override, ...override.policy } : override;
+}
+
+export function resolveDnsPolicy(raw, options = {}) {
+    const override = parseOverride(raw);
+    const input = policyInput(override);
+    const mode = normalizeMode(options.mode || input.mode || input['dns-mode']);
+
+    return {
+        mode,
+        domestic: resolverList(
+            input.domestic || input.domesticNameservers || input['domestic-nameserver'] || input['default-nameserver'],
+            DEFAULT_DNS_POLICY.domestic
+        ),
+        foreign: resolverList(
+            input.foreign || input.foreignNameservers || input['foreign-nameserver'] || input.nameserver,
+            DEFAULT_DNS_POLICY.foreign
+        ),
+        polluted: resolverList(
+            input.polluted || input.pollutedNameservers || input['polluted-nameserver'] || input.fallback,
+            DEFAULT_DNS_POLICY.polluted
+        )
+    };
+}
+
+function withProxy(value, proxyGroup) {
+    const raw = String(value || '').trim();
+    if (!raw || raw === 'system') return raw;
+    return `${raw}#${proxyGroup}`;
+}
+
+function cloneResolverPolicy(policy) {
+    return {
+        mode: policy.mode,
+        domestic: [...policy.domestic],
+        foreign: [...policy.foreign],
+        polluted: [...policy.polluted]
+    };
+}
+
 export const DEFAULT_DNS_CONFIG = {
     enable: true,
     ipv6: false,
     'enhanced-mode': 'fake-ip',
     'fake-ip-range': '198.18.0.1/16',
+    'fake-ip-filter-mode': 'blacklist',
     'fake-ip-filter': [
         'geosite:private',
-        'geosite:category-ntp'
+        'geosite:category-ntp',
+        '*.lan',
+        '*.local',
+        'localhost',
+        '*.arpa'
     ],
     'use-hosts': true,
-    nameserver: [
-        'https://doh.pub/dns-query',
-        'https://dns.alidns.com/dns-query'
-    ],
-    'default-nameserver': [
-        '223.5.5.5',
-        '119.29.29.29'
-    ],
-    fallback: [
-        'https://doh-pure.onedns.net/dns-query',
-        'https://ada.openbld.net/dns-query',
-        'https://223.5.5.5/dns-query',
-        'https://223.6.6.6/dns-query'
-    ],
+    'use-system-hosts': true,
+    'respect-rules': true,
+    'default-nameserver': [...DEFAULT_DNS_POLICY.domestic],
+    nameserver: DEFAULT_DNS_POLICY.foreign.map(value => withProxy(value, DNS_PROXY_GROUP)),
+    'nameserver-policy': {
+        'geosite:private': [...DEFAULT_DNS_POLICY.domestic],
+        'geosite:cn': [...DEFAULT_DNS_POLICY.domestic],
+        'geosite:geolocation-!cn': DEFAULT_DNS_POLICY.foreign.map(value => withProxy(value, DNS_PROXY_GROUP))
+    },
+    'proxy-server-nameserver': [...DEFAULT_DNS_POLICY.domestic],
+    'direct-nameserver': [...DEFAULT_DNS_POLICY.domestic],
+    'direct-nameserver-follow-policy': true,
+    fallback: [],
     'fallback-filter': {
         geoip: true,
-        ipcidr: ['240.0.0.0/4', '0.0.0.0/32']
+        'geoip-code': 'CN',
+        ipcidr: ['240.0.0.0/4', '0.0.0.0/32', '127.0.0.0/8', '100.64.0.0/10']
     }
 };
 
-function cloneDefaultDns() {
-    return {
-        ...DEFAULT_DNS_CONFIG,
-        'fake-ip-filter': [...DEFAULT_DNS_CONFIG['fake-ip-filter']],
-        nameserver: [...DEFAULT_DNS_CONFIG.nameserver],
-        'default-nameserver': [...DEFAULT_DNS_CONFIG['default-nameserver']],
-        fallback: [...DEFAULT_DNS_CONFIG.fallback],
-        'fallback-filter': {
-            ...DEFAULT_DNS_CONFIG['fallback-filter'],
-            ipcidr: [...DEFAULT_DNS_CONFIG['fallback-filter'].ipcidr]
-        }
+export function resolveSafeDnsConfig(raw, options = {}) {
+    const policy = resolveDnsPolicy(raw, options);
+    const proxyGroup = String(options.proxyGroup || DNS_PROXY_GROUP);
+    const foreign = policy.mode === DNS_MODES.POLLUTED ? policy.polluted : policy.foreign;
+    const dns = clone(DEFAULT_DNS_CONFIG);
+
+    dns['default-nameserver'] = [...policy.domestic];
+    dns.nameserver = foreign.map(value => withProxy(value, proxyGroup));
+    dns['nameserver-policy'] = {
+        'geosite:private': [...policy.domestic],
+        'geosite:cn': [...policy.domestic],
+        'geosite:geolocation-!cn': foreign.map(value => withProxy(value, proxyGroup))
     };
-}
+    dns['proxy-server-nameserver'] = [...policy.domestic];
+    dns['direct-nameserver'] = [...policy.domestic];
+    dns.fallback = policy.mode === DNS_MODES.POLLUTED
+        ? foreign.map(value => withProxy(value, proxyGroup))
+        : [];
 
-function parseOverride(raw) {
-    if (typeof raw !== 'string' || !raw.trim()) return null;
-
-    try {
-        const parsed = yaml.load(raw.trim());
-        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
-        const dns = parsed.dns && typeof parsed.dns === 'object' && !Array.isArray(parsed.dns)
-            ? parsed.dns
-            : parsed;
-        return dns && typeof dns === 'object' && !Array.isArray(dns) ? dns : null;
-    } catch {
-        return null;
-    }
-}
-
-/**
- * 解析 DNS 覆盖配置，同时保留安全默认值作为缺失/错误字段的兜底。
- * 强制关闭 IPv6/follow-rule，避免 TUN DNS 递归链再次出现。
- */
-export function resolveSafeDnsConfig(raw) {
-    const override = parseOverride(raw);
-    const dns = { ...cloneDefaultDns(), ...(override || {}) };
+    const override = policyInput(parseOverride(raw));
+    SAFE_DNS_FIELDS.forEach(key => {
+        if (override[key] === undefined) return;
+        if (key === 'fake-ip-filter-mode' && !['blacklist', 'whitelist', 'rule'].includes(String(override[key]))) return;
+        if (['use-hosts', 'use-system-hosts'].includes(key)) {
+            dns[key] = Boolean(override[key]);
+            return;
+        }
+        if (key === 'fake-ip-filter') {
+            if (Array.isArray(override[key]) && override[key].every(item => typeof item === 'string')) {
+                dns[key] = [...override[key]];
+            }
+            return;
+        }
+        if (typeof override[key] === 'string' || typeof override[key] === 'number') dns[key] = override[key];
+    });
 
     dns.enable = true;
     dns.ipv6 = false;
     dns['enhanced-mode'] = 'fake-ip';
-    if (!Array.isArray(dns.nameserver) || dns.nameserver.length === 0) {
-        dns.nameserver = [...DEFAULT_DNS_CONFIG.nameserver];
-    }
-    if (!Array.isArray(dns['default-nameserver']) || dns['default-nameserver'].length === 0) {
-        dns['default-nameserver'] = [...DEFAULT_DNS_CONFIG['default-nameserver']];
-    }
-    if (!Array.isArray(dns.fallback) || dns.fallback.length === 0) {
-        dns.fallback = [...DEFAULT_DNS_CONFIG.fallback];
-    }
-    delete dns['respect-rules'];
-
+    dns['respect-rules'] = true;
     return dns;
+}
+
+function parseSingboxResolver(value, tag, detour) {
+    const raw = String(value || '').trim();
+    const candidate = DNS_SCHEME_PATTERN.test(raw) ? raw : `udp://${raw}`;
+    const parsed = new URL(candidate);
+    const type = parsed.protocol.slice(0, -1);
+    const server = parsed.hostname.replace(/^\[|\]$/g, '');
+    const serverPort = Number(parsed.port) || (type === 'https' ? 443 : type === 'tls' ? 853 : 53);
+    const result = { tag, type, server, server_port: serverPort, detour };
+    if (type === 'https') result.path = parsed.pathname || '/dns-query';
+    if (type === 'tls') result.tls = { enabled: true, server_name: server };
+    return result;
+}
+
+export function buildSingboxDnsConfig(raw, options = {}) {
+    const policy = resolveDnsPolicy(raw, options);
+    const proxyGroup = String(options.proxyGroup || DNS_PROXY_GROUP);
+    const foreign = policy.mode === DNS_MODES.POLLUTED ? policy.polluted : policy.foreign;
+    const domesticServers = policy.domestic.map((value, index) => parseSingboxResolver(value, `dns-cn-${index + 1}`, 'DIRECT'));
+    const foreignServers = foreign.map((value, index) => parseSingboxResolver(value, `dns-foreign-${index + 1}`, proxyGroup));
+    const domesticTag = domesticServers[0]?.tag || 'dns-cn-1';
+    const foreignTag = foreignServers[0]?.tag || 'dns-foreign-1';
+
+    return {
+        strategy: 'prefer_ipv4',
+        servers: [...domesticServers, ...foreignServers],
+        rules: [
+            { domain_suffix: ['.cn', '.lan', '.local'], action: 'route', server: domesticTag }
+        ],
+        final: foreignTag
+    };
+}
+
+export function cloneDnsPolicy(raw, options = {}) {
+    return cloneResolverPolicy(resolveDnsPolicy(raw, options));
 }

--- a/functions/modules/subscription/safe-dns.js
+++ b/functions/modules/subscription/safe-dns.js
@@ -6,6 +6,7 @@ export const DNS_MODES = Object.freeze({
 });
 
 export const DNS_PROXY_GROUP = '🌐 DNS 出口';
+export const SINGBOX_CN_RULE_SET = 'geosite-cn';
 
 export const DEFAULT_DNS_POLICY = Object.freeze({
     domestic: ['223.5.5.5', '119.29.29.29'],
@@ -242,6 +243,7 @@ export function buildSingboxDnsConfig(raw, options = {}) {
         strategy: 'prefer_ipv4',
         servers: [...domesticServers, ...foreignServers],
         rules: [
+            { rule_set: [SINGBOX_CN_RULE_SET], action: 'route', server: domesticTag },
             { domain_suffix: ['.cn', '.lan', '.local'], action: 'route', server: domesticTag }
         ],
         final: foreignTag

--- a/functions/modules/subscription/safe-dns.js
+++ b/functions/modules/subscription/safe-dns.js
@@ -1,0 +1,85 @@
+import yaml from 'js-yaml';
+
+export const DEFAULT_DNS_CONFIG = {
+    enable: true,
+    ipv6: false,
+    'enhanced-mode': 'fake-ip',
+    'fake-ip-range': '198.18.0.1/16',
+    'fake-ip-filter': [
+        'geosite:private',
+        'geosite:category-ntp'
+    ],
+    'use-hosts': true,
+    nameserver: [
+        'https://doh.pub/dns-query',
+        'https://dns.alidns.com/dns-query'
+    ],
+    'default-nameserver': [
+        '223.5.5.5',
+        '119.29.29.29'
+    ],
+    fallback: [
+        'https://doh-pure.onedns.net/dns-query',
+        'https://ada.openbld.net/dns-query',
+        'https://223.5.5.5/dns-query',
+        'https://223.6.6.6/dns-query'
+    ],
+    'fallback-filter': {
+        geoip: true,
+        ipcidr: ['240.0.0.0/4', '0.0.0.0/32']
+    }
+};
+
+function cloneDefaultDns() {
+    return {
+        ...DEFAULT_DNS_CONFIG,
+        'fake-ip-filter': [...DEFAULT_DNS_CONFIG['fake-ip-filter']],
+        nameserver: [...DEFAULT_DNS_CONFIG.nameserver],
+        'default-nameserver': [...DEFAULT_DNS_CONFIG['default-nameserver']],
+        fallback: [...DEFAULT_DNS_CONFIG.fallback],
+        'fallback-filter': {
+            ...DEFAULT_DNS_CONFIG['fallback-filter'],
+            ipcidr: [...DEFAULT_DNS_CONFIG['fallback-filter'].ipcidr]
+        }
+    };
+}
+
+function parseOverride(raw) {
+    if (typeof raw !== 'string' || !raw.trim()) return null;
+
+    try {
+        const parsed = yaml.load(raw.trim());
+        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+        const dns = parsed.dns && typeof parsed.dns === 'object' && !Array.isArray(parsed.dns)
+            ? parsed.dns
+            : parsed;
+        return dns && typeof dns === 'object' && !Array.isArray(dns) ? dns : null;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * 解析 DNS 覆盖配置，同时保留安全默认值作为缺失/错误字段的兜底。
+ * 强制关闭 IPv6/follow-rule，避免 TUN DNS 递归链再次出现。
+ */
+export function resolveSafeDnsConfig(raw) {
+    const override = parseOverride(raw);
+    const dns = { ...cloneDefaultDns(), ...(override || {}) };
+
+    dns.enable = true;
+    dns.ipv6 = false;
+    dns['enhanced-mode'] = 'fake-ip';
+    if (!Array.isArray(dns.nameserver) || dns.nameserver.length === 0) {
+        dns.nameserver = [...DEFAULT_DNS_CONFIG.nameserver];
+    }
+    if (!Array.isArray(dns['default-nameserver']) || dns['default-nameserver'].length === 0) {
+        dns['default-nameserver'] = [...DEFAULT_DNS_CONFIG['default-nameserver']];
+    }
+    if (!Array.isArray(dns.fallback) || dns.fallback.length === 0) {
+        dns.fallback = [...DEFAULT_DNS_CONFIG.fallback];
+    }
+    delete dns['respect-rules'];
+
+    return dns;
+}

--- a/functions/modules/subscription/template-model.js
+++ b/functions/modules/subscription/template-model.js
@@ -14,7 +14,8 @@ export function createUnifiedTemplateModel(input = {}) {
             interval: input.settings?.interval || 86400,
             skipCertVerify: Boolean(input.settings?.skipCertVerify),
             enableUdp: Boolean(input.settings?.enableUdp),
-            customDnsOverride: input.settings?.customDnsOverride || ''
+            customDnsOverride: input.settings?.customDnsOverride || '',
+            dnsMode: input.settings?.dnsMode || 'clean'
         },
         extras: typeof input.extras === 'object' && input.extras !== null ? input.extras : {}
     };

--- a/functions/modules/subscription/template-parsers/ini-template-parser.js
+++ b/functions/modules/subscription/template-parsers/ini-template-parser.js
@@ -1,4 +1,5 @@
 import { createUnifiedTemplateModel } from '../template-model.js';
+import { pinRemoteRuleUrl } from '../builtin-rules-provider.js';
 
 function parseIniSections(templateText) {
     const lines = String(templateText || '').split(/\r?\n/);
@@ -85,7 +86,7 @@ function parseAclRuleSetLine(line) {
 
     return {
         type: 'rule-set',
-        value: source,
+        value: pinRemoteRuleUrl(source),
         policy,
         source: 'remote',
         extras: []
@@ -182,7 +183,8 @@ export function parseIniTemplate(templateText, options = {}) {
             interval: options.interval || 86400,
             skipCertVerify: Boolean(options.skipCertVerify),
             enableUdp: Boolean(options.enableUdp),
-            customDnsOverride: options.customDnsOverride || ''
+            customDnsOverride: options.customDnsOverride || '',
+            dnsMode: options.dnsMode || 'clean'
         }
     });
 }

--- a/functions/modules/subscription/template-processor.js
+++ b/functions/modules/subscription/template-processor.js
@@ -1,4 +1,6 @@
 import { groupNodeLinesByRegion } from './region-groups.js';
+import { AI_SERVICE_RULES } from './builtin-rules-provider.js';
+import { DNS_PROXY_GROUP } from './safe-dns.js';
 
 /**
  * 解析并扩展策略组中的正则过滤器
@@ -189,6 +191,110 @@ function pruneInvalidMembers(model) {
     });
 }
 
+function ensureDnsProxyGroup(model) {
+    if (model.groups.some(group => group.name === DNS_PROXY_GROUP)) return;
+    const proxyNames = model.proxies.map(proxy => proxy.name || proxy.tag).filter(Boolean);
+    model.groups.push({
+        name: DNS_PROXY_GROUP,
+        type: 'url-test',
+        members: proxyNames.length > 0 ? proxyNames : ['REJECT'],
+        filters: [],
+        options: {
+            url: 'http://www.gstatic.com/generate_204',
+            interval: 300,
+            tolerance: 50
+        }
+    });
+}
+
+function isAiGroupName(name) {
+    const value = String(name || '');
+    return /人工智能|智能\s*ai|(?:^|[^a-z])(ai|claude|openai|gemini|grok|mistral|deepseek|perplexity|copilot)(?=$|[^a-z])/i.test(value);
+}
+
+function proxyOnlyMembers(members) {
+    return Array.from(new Set((Array.isArray(members) ? members : []).filter(member =>
+        !['DIRECT', 'REJECT-DROP', 'PASS'].includes(String(member).toUpperCase())
+    )));
+}
+
+function ensureAiPolicy(model) {
+    const aiGroups = model.groups.filter(group => isAiGroupName(group.name));
+    const mainGroup = model.groups.find(group => !isAiGroupName(group.name) && /选择|proxy|default|global|main/i.test(group.name));
+    const fallbackMembers = proxyOnlyMembers(mainGroup?.members);
+    const preferredMembers = proxyOnlyMembers(aiGroups[0]?.members);
+    const nodeMembers = model.proxies.map(proxy => proxy.name || proxy.tag).filter(Boolean);
+    const aiMembers = Array.from(new Set([
+        ...(preferredMembers.length > 0 ? preferredMembers : fallbackMembers),
+        ...(preferredMembers.length > 0 || fallbackMembers.length > 0 ? [] : nodeMembers)
+    ]));
+    const nodeCandidates = aiMembers.length > 0 ? aiMembers : ['REJECT'];
+
+    aiGroups.forEach(group => {
+        group.members = proxyOnlyMembers(group.members);
+        if (group.members.length === 0) group.members = ['REJECT'];
+    });
+
+    const existingNames = new Set(model.groups.map(group => group.name));
+    if (!existingNames.has('🤖 AI 自动')) {
+        model.groups.push({
+            name: '🤖 AI 自动',
+            type: 'url-test',
+            members: nodeCandidates,
+            filters: [],
+            options: { url: 'http://www.gstatic.com/generate_204', interval: 300, tolerance: 50 }
+        });
+        existingNames.add('🤖 AI 自动');
+    }
+    if (!existingNames.has('🤖 AI 故障转移')) {
+        model.groups.push({
+            name: '🤖 AI 故障转移',
+            type: 'fallback',
+            members: nodeCandidates,
+            filters: [],
+            options: { url: 'http://www.gstatic.com/generate_204', interval: 300, tolerance: 50 }
+        });
+        existingNames.add('🤖 AI 故障转移');
+    }
+    if (!existingNames.has('🤖 智能 AI')) {
+        model.groups.push({
+            name: '🤖 智能 AI',
+            type: 'select',
+            members: ['🤖 AI 自动', '🤖 AI 故障转移']
+        });
+        existingNames.add('🤖 智能 AI');
+    }
+    AI_SERVICE_RULES.forEach(service => {
+        const groupName = `🤖 ${service.name}`;
+        if (!existingNames.has(groupName)) {
+            model.groups.push({
+                name: groupName,
+                type: 'select',
+                members: ['🤖 AI 自动', '🤖 AI 故障转移'],
+                filters: [],
+                options: {}
+            });
+            existingNames.add(groupName);
+        }
+    });
+
+    const existingRules = new Set(model.rules.map(rule => `${rule.type}|${rule.value}|${rule.policy}`));
+    const aiRules = [];
+    AI_SERVICE_RULES.forEach(service => service.domains.forEach(domain => {
+        const rule = {
+            type: 'domain-suffix',
+            value: domain,
+            policy: `🤖 ${service.name}`,
+            source: 'inline',
+            extras: []
+        };
+        const key = `${rule.type}|${rule.value}|${rule.policy}`;
+        if (!existingRules.has(key)) aiRules.push(rule);
+    }));
+    // 保留模板作者已有的精确规则优先级；新服务规则只补缺失项。
+    model.rules = [...model.rules, ...aiRules];
+}
+
 /**
  * 模板模型智能优化器（主入口）
  * 包含：自动解析过滤器、注入地区组、展开占位符、清理无效引用及空组
@@ -199,6 +305,12 @@ export function applySmartModelOptimizations(model) {
     
     // 1. 执行现有的正则过滤器解析 (始终执行)
     resolveGroupFilters(model);
+
+    // DNS 出站不能继承普通主组的 DIRECT 选项，否则 TUN 下会泄露或形成递归。
+    ensureDnsProxyGroup(model);
+
+    // AI 服务分组必须代理优先且 fail-closed；同时补齐主要服务的独立域名规则。
+    ensureAiPolicy(model);
 
     // 2. 检查等级。如果是 none (完全禁用)，我们只执行占位符展开和清理，不进行智能注入。
     const normalizedLevel = (ruleLevel || '').toLowerCase();

--- a/functions/modules/subscription/template-renderers/render-clash.js
+++ b/functions/modules/subscription/template-renderers/render-clash.js
@@ -1,6 +1,7 @@
 import yaml from 'js-yaml';
 import { clashFix } from '../../../utils/format-utils.js';
 import { normalizeUnifiedTemplateModel } from '../template-model.js';
+import { resolveSafeDnsConfig } from '../safe-dns.js';
 
 function mapGroupType(type) {
     const normalized = String(type || '').trim().toLowerCase();
@@ -60,36 +61,6 @@ const ACL4SSR_ROOT_LIST_ONLY_FILES = new Set([
     'download',
     'unban'
 ]);
-
-// 解析用户提供的 DNS 覆写片段（支持 JSON 和 YAML），解析失败返回 null
-function parseDnsOverride(raw) {
-    if (!raw || typeof raw !== 'string' || !raw.trim()) return null;
-    try {
-        const trimmed = raw.trim();
-        let parsed;
-        if (/^\{/.test(trimmed)) {
-            parsed = JSON.parse(trimmed);
-        } else {
-            parsed = yaml.load(trimmed);
-        }
-        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-            // 如果 YAML 解析结果包含 dns 顶层键，取 dns 的值
-            if (parsed.dns && typeof parsed.dns === 'object' && !Array.isArray(parsed.dns)) {
-                return parsed.dns;
-            }
-            return parsed;
-        }
-    } catch {
-        // 忽略解析错误，回退到默认
-    }
-    return null;
-}
-
-// 合并用户 DNS 覆写：有覆写则完全替换，无覆写则用默认
-function mergeDnsConfig(defaultDns, override) {
-    if (!override) return defaultDns;
-    return override;
-}
 
 function toClashRuleProviderUrl(sourceUrl) {
     if (!/^https?:\/\//i.test(String(sourceUrl || ''))) return sourceUrl;
@@ -188,36 +159,6 @@ export function renderClashFromTemplateModel(model) {
         };
     });
 
-    const dnsOverride = parseDnsOverride(normalizedModel.settings?.customDnsOverride);
-
-    const defaultDns = {
-        'enable': true,
-        'ipv6': true,
-        'enhanced-mode': 'fake-ip',
-        'fake-ip-range': '198.18.0.1/16',
-        'fake-ip-filter': [
-            'geosite:private',
-            'geosite:category-ntp'
-        ],
-        'use-hosts': false,
-        'use-system-hosts': false,
-        'nameserver': [
-            'https://1.1.1.1/dns-query',
-            'https://8.8.8.8/dns-query'
-        ],
-        'proxy-server-nameserver': [
-            'https://223.5.5.5/dns-query',
-            'https://223.6.6.6/dns-query'
-        ],
-        'nameserver-policy': {
-            'geosite:cn': [
-                'https://223.5.5.5/dns-query',
-                'https://223.6.6.6/dns-query'
-            ]
-        },
-        'respect-rules': true
-    };
-
     const config = {
         'mixed-port': 7890,
         'socks-port': 7891,
@@ -227,7 +168,7 @@ export function renderClashFromTemplateModel(model) {
         'mode': 'rule',
         'log-level': 'info',
         'external-controller': ':9090',
-        'dns': mergeDnsConfig(defaultDns, dnsOverride),
+        'dns': resolveSafeDnsConfig(normalizedModel.settings?.customDnsOverride),
         'proxies': normalizedModel.proxies,
         'proxy-groups': normalizedModel.groups
             .filter(group =>

--- a/functions/modules/subscription/template-renderers/render-clash.js
+++ b/functions/modules/subscription/template-renderers/render-clash.js
@@ -1,7 +1,7 @@
 import yaml from 'js-yaml';
 import { clashFix } from '../../../utils/format-utils.js';
 import { normalizeUnifiedTemplateModel } from '../template-model.js';
-import { resolveSafeDnsConfig } from '../safe-dns.js';
+import { DNS_PROXY_GROUP, resolveSafeDnsConfig } from '../safe-dns.js';
 
 function mapGroupType(type) {
     const normalized = String(type || '').trim().toLowerCase();
@@ -162,13 +162,16 @@ export function renderClashFromTemplateModel(model) {
     const config = {
         'mixed-port': 7890,
         'socks-port': 7891,
-        'allow-lan': true,
-        'bind-address': '*',
-        'ipv6': true,
+        'allow-lan': false,
+        'bind-address': '127.0.0.1',
+        'ipv6': false,
         'mode': 'rule',
         'log-level': 'info',
-        'external-controller': ':9090',
-        'dns': resolveSafeDnsConfig(normalizedModel.settings?.customDnsOverride),
+        'external-controller': '127.0.0.1:9090',
+        'dns': resolveSafeDnsConfig(normalizedModel.settings?.customDnsOverride, {
+            mode: normalizedModel.settings?.dnsMode,
+            proxyGroup: DNS_PROXY_GROUP
+        }),
         'proxies': normalizedModel.proxies,
         'proxy-groups': normalizedModel.groups
             .filter(group =>

--- a/functions/modules/subscription/template-renderers/render-singbox.js
+++ b/functions/modules/subscription/template-renderers/render-singbox.js
@@ -1,7 +1,7 @@
 import { urlsToClashProxies } from '../../../utils/url-to-clash.js';
 import { normalizeUnifiedTemplateModel } from '../template-model.js';
-import { buildSingboxDnsConfig, DNS_PROXY_GROUP } from '../safe-dns.js';
-import { pinRemoteRuleUrl } from '../builtin-rules-provider.js';
+import { buildSingboxDnsConfig, DNS_PROXY_GROUP, SINGBOX_CN_RULE_SET } from '../safe-dns.js';
+import { getSingboxDnsRuleSet, pinRemoteRuleUrl } from '../builtin-rules-provider.js';
 
 function sanitizeTag(value) {
     return String(value || '').trim() || 'Untitled';
@@ -360,7 +360,10 @@ export function renderSingboxFromTemplateModel(model, options = {}) {
         : urlsToClashProxies(proxyUrls);
     const proxyOutbounds = proxies.map(buildOutbound).filter(Boolean);
     const groupOutbounds = buildGroupOutbounds(normalizedModel.groups.filter(g => Array.isArray(g.members) && g.members.length > 0));
-    const ruleSetObjects = buildRuleSets(normalizedModel.rules);
+    const ruleSetObjects = [
+        getSingboxDnsRuleSet(),
+        ...buildRuleSets(normalizedModel.rules).filter(ruleSet => ruleSet.tag !== SINGBOX_CN_RULE_SET)
+    ];
     const routeRules = normalizedModel.rules.map(mapRuleToSingbox).filter(Boolean);
     const defaultOutbound = normalizedModel.groups.find(group => group.name !== DNS_PROXY_GROUP)?.name || 'DIRECT';
     const dnsConfig = buildSingboxDnsConfig(normalizedModel.settings?.customDnsOverride, {

--- a/functions/modules/subscription/template-renderers/render-singbox.js
+++ b/functions/modules/subscription/template-renderers/render-singbox.js
@@ -1,5 +1,7 @@
 import { urlsToClashProxies } from '../../../utils/url-to-clash.js';
 import { normalizeUnifiedTemplateModel } from '../template-model.js';
+import { buildSingboxDnsConfig, DNS_PROXY_GROUP } from '../safe-dns.js';
+import { pinRemoteRuleUrl } from '../builtin-rules-provider.js';
 
 function sanitizeTag(value) {
     return String(value || '').trim() || 'Untitled';
@@ -314,8 +316,9 @@ function buildRuleSets(rules) {
             tag: sanitizeTag(`${rule.policy}_${rule.value}`),
             type: 'remote',
             format: detectRuleSetFormat(rule.value),
-            url: rule.value,
-            download_detour: 'DIRECT'
+            url: pinRemoteRuleUrl(rule.value),
+            update_interval: '24h',
+            download_detour: DNS_PROXY_GROUP
         }));
 
     const implicitRuleSets = [];
@@ -333,9 +336,10 @@ function buildRuleSets(rules) {
                     type: 'remote',
                     format: 'binary',
                     url: type === 'geoip'
-                        ? `https://raw.githubusercontent.com/SagerNet/sing-geoip/rule-set/geoip-${value}.srs`
-                        : `https://raw.githubusercontent.com/SagerNet/sing-geosite/rule-set/geosite-${value}.srs`,
-                    download_detour: 'DIRECT'
+                        ? pinRemoteRuleUrl(`https://raw.githubusercontent.com/SagerNet/sing-geoip/rule-set/geoip-${value}.srs`)
+                        : pinRemoteRuleUrl(`https://raw.githubusercontent.com/SagerNet/sing-geosite/rule-set/geosite-${value}.srs`),
+                    update_interval: '24h',
+                    download_detour: DNS_PROXY_GROUP
                 });
             }
         }
@@ -358,16 +362,23 @@ export function renderSingboxFromTemplateModel(model, options = {}) {
     const groupOutbounds = buildGroupOutbounds(normalizedModel.groups.filter(g => Array.isArray(g.members) && g.members.length > 0));
     const ruleSetObjects = buildRuleSets(normalizedModel.rules);
     const routeRules = normalizedModel.rules.map(mapRuleToSingbox).filter(Boolean);
+    const defaultOutbound = normalizedModel.groups.find(group => group.name !== DNS_PROXY_GROUP)?.name || 'DIRECT';
+    const dnsConfig = buildSingboxDnsConfig(normalizedModel.settings?.customDnsOverride, {
+        mode: normalizedModel.settings?.dnsMode,
+        proxyGroup: DNS_PROXY_GROUP
+    });
 
     const config = {
         log: { level: 'info' },
-        dns: {
-            strategy: 'prefer_ipv4',
-            servers: [
-                { tag: 'dns-ali', type: 'udp', server: '223.5.5.5', server_port: 53, detour: 'DIRECT' },
-                { tag: 'dns-google', type: 'udp', server: '8.8.8.8', server_port: 53, detour: 'DIRECT' }
-            ]
-        },
+        dns: dnsConfig,
+        inbounds: [{
+            type: 'tun',
+            tag: 'tun-in',
+            address: ['172.19.0.1/30'],
+            auto_route: true,
+            strict_route: true,
+            stack: 'mixed'
+        }],
         outbounds: [
             { tag: 'DIRECT', type: 'direct' },
             { tag: 'REJECT', type: 'block' },
@@ -376,7 +387,8 @@ export function renderSingboxFromTemplateModel(model, options = {}) {
         ],
         route: {
             auto_detect_interface: true,
-            final: normalizedModel.groups[0]?.name || 'DIRECT',
+            default_domain_resolver: dnsConfig.servers[0]?.tag || 'dns-cn-1',
+            final: defaultOutbound,
             rule_set: ruleSetObjects,
             rules: routeRules
         }

--- a/functions/services/processor-service.js
+++ b/functions/services/processor-service.js
@@ -12,6 +12,7 @@ import { resolveRuleTemplateSource } from '../modules/rule-template-handler.js';
 import { base64EncodeUtf8 } from '../modules/utils.js';
 import yaml from 'js-yaml';
 import { urlsToClashProxies } from '../utils/url-to-clash.js';
+import { resolveSafeDnsConfig } from '../modules/subscription/safe-dns.js';
 
 function getTemplateExtension(templateUrl) {
     const raw = typeof templateUrl === 'string' ? templateUrl.trim() : '';
@@ -83,6 +84,14 @@ export function renderClashYamlProfileTemplate(templateText, nodeList, options =
 
     return yaml.dump({
         ...config,
+        'allow-lan': false,
+        'bind-address': '127.0.0.1',
+        'ipv6': false,
+        'external-controller': '127.0.0.1:9090',
+        dns: resolveSafeDnsConfig(config.dns, {
+            mode: options.dnsMode,
+            proxyGroup: '🌐 DNS 出口'
+        }),
         proxies
     }, {
         indent: 2,
@@ -190,7 +199,8 @@ export class ProcessorService {
                     skipCertVerify: builtinOptions.skipCertVerify,
                     enableUdp: builtinOptions.enableUdp,
                     isMeta: builtinOptions.isMeta,
-                    customDnsOverride: builtinOptions.customDnsOverride || ''
+                    customDnsOverride: builtinOptions.customDnsOverride || '',
+                    dnsMode: builtinOptions.dnsMode || 'clean'
                 };
 
                 switch (targetFormat) {

--- a/functions/services/subscription-service.js
+++ b/functions/services/subscription-service.js
@@ -7,7 +7,7 @@ import { parseNodeList } from '../modules/utils/node-parser.js';
 import { parseNodeInfo } from '../modules/utils/geo-utils.js';
 import { getProcessedUserAgent } from '../utils/format-utils.js';
 import { buildFetchProxyUrl } from '../utils/fetch-proxy-utils.js';
-import { prependNodeName, addFlagEmoji, removeFlagEmoji, fixNodeUrlEncoding, sanitizeNodeForYaml } from '../utils/node-utils.js';
+import { prependNodeName, addFlagEmoji, removeFlagEmoji, fixNodeUrlEncoding, sanitizeNodeForYaml, isLocalProxyEndpoint } from '../utils/node-utils.js';
 import { runOperatorChain } from '../utils/operator-runner.js';
 import { createTimeoutFetch } from '../modules/utils.js';
 import { assertPublicNetworkUrl } from '../modules/security-utils.js';
@@ -47,6 +47,7 @@ export function isRealProxyNode(node) {
     if (typeof node !== 'string') return false;
     const trimmed = node.trim().toLowerCase();
     if (!trimmed) return false;
+    if (isLocalProxyEndpoint(trimmed)) return false;
     return REAL_PROXY_PROTOCOLS.some(protocol => trimmed.startsWith(protocol));
 }
 

--- a/functions/utils/node-utils.js
+++ b/functions/utils/node-utils.js
@@ -12,6 +12,33 @@ import { extractNodeMetadata } from '../modules/utils/metadata-extractor.js';
  */
 export const NODE_PROTOCOL_REGEX = /^(ss|ssr|vmess|vless|trojan|hysteria2?|hy|hy2|tuic|snell|anytls|socks5|socks|wireguard|naive\+https?|naive\+quic):\/\//i;
 
+/**
+ * 判断代理是否指向本机/未指定地址。
+ * 这类地址不能作为订阅中的真实出口节点。
+ */
+export function isLocalProxyEndpoint(proxy) {
+    let host = '';
+
+    if (proxy && typeof proxy === 'object') {
+        host = proxy.server || proxy.host || '';
+    } else if (typeof proxy === 'string') {
+        try {
+            host = new URL(proxy).hostname;
+        } catch {
+            const match = proxy.match(/@(?:\[([^\]]+)\]|([^:?#/]+))/);
+            host = match?.[1] || match?.[2] || '';
+        }
+    }
+
+    host = String(host).trim().toLowerCase().replace(/^\[|\]$/g, '').replace(/\.$/, '');
+    return host === 'localhost'
+        || host === '::1'
+        || host === '::'
+        || host === '0.0.0.0'
+        || /^127(?:\.\d{1,3}){3}$/.test(host)
+        || /^::ffff:127(?:\.\d{1,3}){3}$/.test(host);
+}
+
 function normalizeBase64(input) {
     let normalized = String(input || '').replace(/\s+/g, '').replace(/-/g, '+').replace(/_/g, '/');
     const padding = normalized.length % 4;

--- a/functions/utils/url-to-clash.js
+++ b/functions/utils/url-to-clash.js
@@ -3,6 +3,7 @@
  */
 
 import { extractNodeMetadata } from '../modules/utils/metadata-extractor.js';
+import { isLocalProxyEndpoint } from './node-utils.js';
 
 /**
  * 解析 URL 查询参数
@@ -1503,7 +1504,7 @@ export function urlsToClashProxies(urls, options = {}) {
             
             return proxy;
         })
-        .filter(proxy => proxy !== null);
+        .filter(proxy => proxy !== null && !isLocalProxyEndpoint(proxy));
 }
 
 /**

--- a/functions/utils/url-to-clash.js
+++ b/functions/utils/url-to-clash.js
@@ -987,15 +987,15 @@ const { server, port } = parseHostPort(serverPart);
 const params = parseQueryParams(url);
 const name = extractName(url);
 
-const proxy = {
-name: name || `WireGuard-${server}`,
-type: 'wireguard',
-server,
-port,
-'private-key': privateKey,
-// 'remote-dns-resolve': true, // just let the kernel decide whether to use it or not
-udp: true
-};
+    const proxy = {
+        name: name || `WireGuard-${server}`,
+        type: 'wireguard',
+        server,
+        port,
+        'private-key': privateKey,
+        'remote-dns-resolve': true,
+        udp: true
+    };
 
 // 公钥
 const publicKey = params.get('publickey') || params.get('public-key');
@@ -1003,12 +1003,8 @@ if (publicKey) {
 proxy['public-key'] = publicKey;
 }
 
-// 本地地址
-// const address = params.get('address');
-// if (address) {
-// proxy.ip = address.split(',').map(a => a.trim());
-// }
-// IPv6 Support
+// 本地地址。保留 WireGuard 的 CIDR 和多地址形状，避免转换往返时丢失
+// 隧道前缀；同时提供 ipv6 兼容字段给需要独立 IPv6 字段的渲染器。
 const address = params.get('address');
 if (address) {
     const addresses = address
@@ -1016,16 +1012,10 @@ if (address) {
         .map(a => a.trim())
         .filter(Boolean);
 
-    const ipv4 = addresses.find(a => !a.includes(':'));
     const ipv6 = addresses.find(a => a.includes(':'));
 
-    if (ipv4) {
-        proxy.ip = ipv4.replace(/\/\d+$/, '');
-    }
-
-    if (ipv6) {
-        proxy.ipv6 = ipv6.replace(/\/\d+$/, '');
-    }
+    if (addresses.length > 0) proxy.ip = addresses;
+    if (ipv6) proxy.ipv6 = ipv6;
 }
 
 // Allowed IPs

--- a/scripts/smoke-subscription.mjs
+++ b/scripts/smoke-subscription.mjs
@@ -1,0 +1,133 @@
+import yaml from 'js-yaml';
+import { pathToFileURL } from 'node:url';
+import { PINNED_RULE_REVISIONS } from '../functions/modules/subscription/builtin-rules-provider.js';
+import { DNS_PROXY_GROUP, SINGBOX_CN_RULE_SET } from '../functions/modules/subscription/safe-dns.js';
+
+function assert(condition, message) {
+    if (!condition) throw new Error(message);
+}
+
+function array(value) {
+    return Array.isArray(value) ? value : [];
+}
+
+function isLoopbackHost(value) {
+    const host = String(value || '').trim().replace(/^\[|\]$/g, '').toLowerCase();
+    return host === 'localhost' || host === '::1' || host === '::' || host === '0.0.0.0' || host.startsWith('127.');
+}
+
+function assertNoLoopbackNodes(nodes, label) {
+    for (const node of array(nodes)) {
+        if (node?.server && isLoopbackHost(node.server)) {
+            throw new Error(`${label} contains loopback proxy endpoint`);
+        }
+    }
+}
+
+function assertDnsMode(values, mode, label) {
+    const servers = array(values);
+    assert(servers.length > 0, `${label} has no DNS servers`);
+    if (mode === 'clean') {
+        assert(servers.every(server => /^udp:\/\//i.test(String(server))), `${label} clean mode is not plaintext UDP`);
+        assert(servers.every(server => !/^https?:\/\//i.test(String(server))), `${label} clean mode contains encrypted DNS`);
+    } else {
+        assert(servers.every(server => /^(?:https|tls):\/\//i.test(String(server))), `${label} polluted mode is not encrypted DNS`);
+        assert(servers.every(server => String(server).endsWith(`#${DNS_PROXY_GROUP}`)), `${label} polluted DNS is not proxied`);
+    }
+}
+
+export function validateClashConfig(config, mode) {
+    assert(config && typeof config === 'object', 'Clash output is not an object');
+    assert(config.ipv6 === false, 'Clash IPv6 is enabled');
+    assert(config['allow-lan'] === false, 'Clash LAN access is enabled');
+    assert(config['bind-address'] === '127.0.0.1', 'Clash bind address is not loopback-only');
+    assert(config['external-controller'] === '127.0.0.1:9090', 'Clash controller is not loopback-only');
+
+    const dns = config.dns || {};
+    assert(dns['enhanced-mode'] === 'fake-ip', 'Clash fake-ip mode is missing');
+    assert(dns['respect-rules'] === true, 'Clash DNS respect-rules is disabled');
+    assertDnsMode(dns.nameserver, mode, 'Clash DNS');
+    if (mode === 'clean') assert(array(dns.fallback).length === 0, 'Clash clean mode has fallback DNS');
+    assert(array(dns['nameserver-policy']?.['geosite:cn']).length > 0, 'Clash geosite:cn DNS policy is missing');
+
+    assertNoLoopbackNodes(config.proxies, 'Clash');
+    const aiGroups = array(config['proxy-groups']).filter(group => String(group?.name || '').startsWith('🤖'));
+    assert(aiGroups.length > 0, 'Clash AI groups are missing');
+    assert(aiGroups.every(group => !array(group.proxies).includes('DIRECT')), 'Clash AI group allows DIRECT');
+    return true;
+}
+
+export function validateSingboxConfig(config, mode) {
+    assert(config && typeof config === 'object', 'sing-box output is not an object');
+    const tun = array(config.inbounds).find(inbound => inbound?.type === 'tun');
+    assert(tun, 'sing-box TUN inbound is missing');
+    assert(tun.auto_route === true && tun.strict_route === true && tun.stack === 'mixed', 'sing-box TUN route hardening is incomplete');
+    assert(array(tun.address).includes('172.19.0.1/30'), 'sing-box TUN address is unexpected');
+    assert(config.route?.auto_detect_interface === true, 'sing-box auto interface detection is disabled');
+
+    const dns = config.dns || {};
+    assert(dns.strategy === 'prefer_ipv4', 'sing-box DNS strategy is not prefer_ipv4');
+    assert(array(dns.rules).some(rule => array(rule.rule_set).includes(SINGBOX_CN_RULE_SET) && rule.server === 'dns-cn-1'), 'sing-box geosite-cn DNS route is missing');
+    const cnRuleSet = array(config.route?.rule_set).find(ruleSet => ruleSet?.tag === SINGBOX_CN_RULE_SET);
+    assert(cnRuleSet?.type === 'remote' && cnRuleSet.format === 'binary', 'sing-box geosite-cn rule-set definition is missing');
+    assert(String(cnRuleSet.url || '').includes(PINNED_RULE_REVISIONS.SING_GEOSITE), 'sing-box geosite-cn rule-set is not SHA-pinned');
+
+    const domestic = array(dns.servers).filter(server => String(server?.tag || '').startsWith('dns-cn-'));
+    const foreign = array(dns.servers).filter(server => String(server?.tag || '').startsWith('dns-foreign-'));
+    assert(domestic.length > 0 && domestic.every(server => server.type === 'udp' && server.detour === 'DIRECT'), 'sing-box domestic DNS path is not direct plaintext');
+    assertDnsMode(foreign.map(server => `${server.type}://${server.server}${server.detour === DNS_PROXY_GROUP ? `#${DNS_PROXY_GROUP}` : ''}`), mode, 'sing-box foreign DNS');
+    assert(foreign.every(server => server.detour === DNS_PROXY_GROUP), 'sing-box foreign DNS is not proxied');
+
+    assertNoLoopbackNodes(array(config.outbounds).filter(outbound => outbound?.server), 'sing-box');
+    const aiGroups = array(config.outbounds).filter(outbound => String(outbound?.tag || '').startsWith('🤖'));
+    assert(aiGroups.length > 0, 'sing-box AI groups are missing');
+    assert(aiGroups.every(group => !array(group.outbounds).includes('DIRECT')), 'sing-box AI group allows DIRECT');
+    return true;
+}
+
+async function fetchConfig(baseUrl, params) {
+    const url = new URL(baseUrl);
+    url.searchParams.delete('clash');
+    url.searchParams.delete('singbox');
+    url.searchParams.delete('dns-mode');
+    for (const [key, value] of Object.entries(params)) url.searchParams.set(key, value);
+
+    let lastError;
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), 20_000);
+        try {
+            const response = await fetch(url, { signal: controller.signal, redirect: 'follow' });
+            const body = await response.text();
+            if (!response.ok) throw new Error(`HTTP ${response.status}`);
+            return body;
+        } catch (error) {
+            lastError = error;
+            if (attempt < 2) await new Promise(resolve => setTimeout(resolve, 500 * (attempt + 1)));
+        } finally {
+            clearTimeout(timeout);
+        }
+    }
+    throw lastError || new Error('request failed');
+}
+
+export async function runSmoke(baseUrl) {
+    assert(baseUrl, 'MISUB_SMOKE_URL is not set');
+    for (const mode of ['clean', 'polluted']) {
+        const suffix = mode === 'clean' ? {} : { 'dns-mode': 'polluted' };
+        const clash = yaml.load(await fetchConfig(baseUrl, { clash: '3', extend: '1', ...suffix }));
+        validateClashConfig(clash, mode);
+        console.log(`smoke: Clash ${mode} passed`);
+
+        const singbox = JSON.parse(await fetchConfig(baseUrl, { singbox: '1', extend: '1', ...suffix }));
+        validateSingboxConfig(singbox, mode);
+        console.log(`smoke: sing-box ${mode} passed`);
+    }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+    runSmoke(process.env.MISUB_SMOKE_URL?.trim()).catch(error => {
+        console.error(`subscription smoke failed: ${error.message}`);
+        process.exitCode = 1;
+    });
+}

--- a/tests/unit/builtin-clash-generator.test.js
+++ b/tests/unit/builtin-clash-generator.test.js
@@ -23,10 +23,14 @@ describe('Clash 内置生成器', () => {
         const parsed = yaml.load(result);
 
         expect(parsed.proxies.map(proxy => proxy.server)).toEqual(['example.com']);
+        expect(parsed['allow-lan']).toBe(false);
+        expect(parsed['bind-address']).toBe('127.0.0.1');
+        expect(parsed['external-controller']).toBe('127.0.0.1:9090');
         expect(parsed.dns.ipv6).toBe(false);
         expect(parsed.dns['enhanced-mode']).toBe('fake-ip');
-        expect(parsed.dns['respect-rules']).toBeUndefined();
-        expect(parsed.dns.nameserver).toContain('https://doh.pub/dns-query');
+        expect(parsed.dns['respect-rules']).toBe(true);
+        expect(parsed.dns.nameserver).toContain('udp://8.8.8.8:53#🌐 DNS 出口');
+        expect(parsed.dns['nameserver-policy']['geosite:cn']).toEqual(['223.5.5.5', '119.29.29.29']);
     });
     it('should render SS v2ray-plugin mux as a boolean for Clash compatibility', () => {
         const node = 'ss://MjAyMi1ibGFrZTMtYWVzLTI1Ni1nY206TldSak1UVmxNVFZtTWpnMU5HRTVaRGsxT1dJd1pUUm1ZbVJrTnpkaU5qTT0@cf.090227.xyz:8080?plugin=v2ray-plugin%3Bmode%3Dwebsocket%3Bhost%3Dss.2227tsj.workers.dev%3Bpath%3D%2F%3Fenc%5C%3D2022-blake3-aes-256-gcm%3Bmux%3D0#2022-blake3-aes-256-gcm';
@@ -102,5 +106,17 @@ describe('Clash 内置生成器', () => {
         expect(usGroup.proxies).toContain('🇸🇬 机场A 新加坡 原生');
         expect(usGroup.proxies).toContain('🇺🇸 机场A US-West');
         expect(sgGroup).toBeUndefined();
+    });
+
+    it('应为主要 AI 服务生成独立的代理组且不允许 DIRECT', () => {
+        const parsed = yaml.load(generateBuiltinClashConfig('trojan://password@example.com:443#US-01'));
+
+        for (const name of ['🤖 智能 AI', '🤖 OpenAI', '🤖 Claude', '🤖 Gemini', '🤖 Grok', '🤖 Perplexity', '🤖 Mistral']) {
+            const group = parsed['proxy-groups'].find(item => item.name === name);
+            expect(group, `${name} should exist`).toBeTruthy();
+            expect(group.proxies).not.toContain('DIRECT');
+        }
+        expect(parsed.rules).toContain('DOMAIN-SUFFIX,claude.ai,🤖 Claude');
+        expect(parsed.rules).toContain('DOMAIN-SUFFIX,grok.com,🤖 Grok');
     });
 });

--- a/tests/unit/builtin-clash-generator.test.js
+++ b/tests/unit/builtin-clash-generator.test.js
@@ -14,6 +14,20 @@ describe('Clash 内置生成器', () => {
         const result = generateProxiesOnly(nodeWithControl);
         expect(result).toContain('TestSS');
     });
+
+    it('应使用安全 DNS 默认值并过滤本机伪节点', () => {
+        const result = generateBuiltinClashConfig([
+            'trojan://fake@127.0.0.1:443#伪节点',
+            'trojan://real@example.com:443#真实节点'
+        ].join('\n'));
+        const parsed = yaml.load(result);
+
+        expect(parsed.proxies.map(proxy => proxy.server)).toEqual(['example.com']);
+        expect(parsed.dns.ipv6).toBe(false);
+        expect(parsed.dns['enhanced-mode']).toBe('fake-ip');
+        expect(parsed.dns['respect-rules']).toBeUndefined();
+        expect(parsed.dns.nameserver).toContain('https://doh.pub/dns-query');
+    });
     it('should render SS v2ray-plugin mux as a boolean for Clash compatibility', () => {
         const node = 'ss://MjAyMi1ibGFrZTMtYWVzLTI1Ni1nY206TldSak1UVmxNVFZtTWpnMU5HRTVaRGsxT1dJd1pUUm1ZbVJrTnpkaU5qTT0@cf.090227.xyz:8080?plugin=v2ray-plugin%3Bmode%3Dwebsocket%3Bhost%3Dss.2227tsj.workers.dev%3Bpath%3D%2F%3Fenc%5C%3D2022-blake3-aes-256-gcm%3Bmux%3D0#2022-blake3-aes-256-gcm';
         const result = generateProxiesOnly(node);

--- a/tests/unit/builtin-singbox-generator.test.js
+++ b/tests/unit/builtin-singbox-generator.test.js
@@ -39,6 +39,12 @@ describe('Built-in Sing-box generator', () => {
         expect(parsed.dns.rules).toEqual(expect.arrayContaining([
             expect.objectContaining({ action: 'route', server: 'dns-cn-1' })
         ]));
+        expect(parsed.dns.rules).toEqual(expect.arrayContaining([
+            expect.objectContaining({ rule_set: ['geosite-cn'], action: 'route', server: 'dns-cn-1' })
+        ]));
+        expect(parsed.route.rule_set).toEqual(expect.arrayContaining([
+            expect.objectContaining({ tag: 'geosite-cn', type: 'remote', format: 'binary' })
+        ]));
         expect(parsed.outbounds.find(outbound => outbound.tag === '🌐 DNS 出口')?.outbounds).not.toContain('DIRECT');
     });
 
@@ -82,6 +88,7 @@ describe('Built-in Sing-box generator', () => {
             expect.objectContaining({ type: 'https', server: '8.8.8.8', path: '/dns-query', detour: '🌐 DNS 出口' })
         ]));
         expect(parsed.dns.final).toBe('dns-foreign-1');
+        expect(parsed.dns.rules[0].rule_set).toEqual(['geosite-cn']);
     });
 
     it('should map anytls outbound', () => {

--- a/tests/unit/builtin-singbox-generator.test.js
+++ b/tests/unit/builtin-singbox-generator.test.js
@@ -34,6 +34,12 @@ describe('Built-in Sing-box generator', () => {
             })
         ]);
         expect(parsed.inbounds[0].address).toEqual(expect.arrayContaining(['172.19.0.1/30']));
+        expect(parsed.route.auto_detect_interface).toBe(true);
+        expect(parsed.route.default_domain_resolver).toBe('dns-cn-1');
+        expect(parsed.dns.rules).toEqual(expect.arrayContaining([
+            expect.objectContaining({ action: 'route', server: 'dns-cn-1' })
+        ]));
+        expect(parsed.outbounds.find(outbound => outbound.tag === '🌐 DNS 出口')?.outbounds).not.toContain('DIRECT');
     });
 
     it('should enable TLS for https and socks5-tls', () => {
@@ -50,14 +56,14 @@ describe('Built-in Sing-box generator', () => {
         expect(socksNode?.tls?.enabled).toBe(true);
     });
 
-    it('uses current DNS server objects while preserving Trojan websocket transport', () => {
+    it('uses split DNS server objects while preserving Trojan websocket transport', () => {
         const result = generateBuiltinSingboxConfig('trojan://password@1.2.3.4:443?type=ws&path=%2Fws&host=example.com&sni=example.org#TrojanWS');
         const parsed = JSON.parse(result);
         const trojanNode = parsed.outbounds.find(outbound => outbound.tag.endsWith('TrojanWS'));
 
         expect(parsed.dns.servers).toEqual(expect.arrayContaining([
             expect.objectContaining({ type: 'udp', server: '223.5.5.5', server_port: 53 }),
-            expect.objectContaining({ type: 'https', server: '1.1.1.1', path: '/dns-query' })
+            expect.objectContaining({ type: 'udp', server: '8.8.8.8', detour: '🌐 DNS 出口' })
         ]));
         expect(parsed.dns.servers.every(server => !Object.hasOwn(server, 'address'))).toBe(true);
         expect(trojanNode?.type).toBe('trojan');
@@ -66,6 +72,16 @@ describe('Built-in Sing-box generator', () => {
         expect(trojanNode?.transport?.type).toBe('ws');
         expect(trojanNode?.transport?.path).toBe('/ws');
         expect(trojanNode?.transport?.headers?.Host).toBe('example.com');
+    });
+
+    it('enables encrypted foreign DNS only in polluted mode', () => {
+        const parsed = JSON.parse(generateBuiltinSingboxConfig('trojan://password@1.2.3.4:443#Trojan', {
+            dnsMode: 'polluted'
+        }));
+        expect(parsed.dns.servers).toEqual(expect.arrayContaining([
+            expect.objectContaining({ type: 'https', server: '8.8.8.8', path: '/dns-query', detour: '🌐 DNS 出口' })
+        ]));
+        expect(parsed.dns.final).toBe('dns-foreign-1');
     });
 
     it('should map anytls outbound', () => {

--- a/tests/unit/builtin-surge-generator.test.js
+++ b/tests/unit/builtin-surge-generator.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { generateBuiltinSurgeConfig } from '../../functions/modules/subscription/builtin-surge-generator.js';
+import { PINNED_RULE_REVISIONS } from '../../functions/modules/subscription/builtin-rules-provider.js';
 
 describe('Surge 内置生成器', () => {
     describe('基础功能', () => {
@@ -283,8 +284,8 @@ describe('Surge 内置生成器', () => {
         it('应包含高级分流规则', () => {
             const ss = 'ss://YWVzLTEyOC1nY206cGFzc3dvcmQ=@1.2.3.4:8388#TestSS';
             const result = generateBuiltinSurgeConfig(ss);
-            expect(result).toContain('RULE-SET,https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Apple.list,🍎 Apple');
-            expect(result).toContain('RULE-SET,https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Netflix.list,🎥 流媒体');
+            expect(result).toContain(`RULE-SET,https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/${PINNED_RULE_REVISIONS.ACL4SSR}/Clash/Apple.list,🍎 Apple`);
+            expect(result).toContain(`RULE-SET,https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/${PINNED_RULE_REVISIONS.ACL4SSR}/Clash/Netflix.list,🎥 流媒体`);
             expect(result).toContain('GEOIP,CN,DIRECT');
             expect(result).toContain('FINAL,🚀 节点选择,dns-failed');
         });

--- a/tests/unit/builtin-template-rules-audit.test.js
+++ b/tests/unit/builtin-template-rules-audit.test.js
@@ -4,6 +4,7 @@ import { parseIniTemplate } from '../../functions/modules/subscription/template-
 import { applySmartModelOptimizations } from '../../functions/modules/subscription/template-processor.js';
 import { TRANSFORM_ASSETS } from '../../src/constants/transform-assets.js';
 import { getBuiltinRules, getRemoteProviderDefinitions, REMOTE_SOURCES } from '../../functions/modules/subscription/builtin-rules-provider.js';
+import { DNS_PROXY_GROUP } from '../../functions/modules/subscription/safe-dns.js';
 import { generateBuiltinSingboxConfig } from '../../functions/modules/subscription/builtin-singbox-generator.js';
 import { renderClashFromTemplateModel } from '../../functions/modules/subscription/template-renderers/render-clash.js';
 import { renderSingboxFromTemplateModel } from '../../functions/modules/subscription/template-renderers/render-singbox.js';
@@ -123,7 +124,7 @@ describe('Builtin template rule audit', () => {
         const rawRules = getBuiltinRules('FULL', 'singbox');
         const providers = getRemoteProviderDefinitions('singbox', rawRules);
 
-        expect(REMOTE_SOURCES.ADS.singbox).toBe('https://raw.githubusercontent.com/SagerNet/sing-geosite/rule-set/geosite-category-ads-all.srs');
+        expect(REMOTE_SOURCES.ADS.singbox).toMatch(/\/0adeef8a3b9201292f6786ef4de81bcc02e971eb\/geosite-category-ads-all\.srs$/);
         expect(Object.values(REMOTE_SOURCES).every(source => !source.singbox?.includes('Loyalsoldier/sing-box-rules'))).toBe(true);
         expect(Object.values(providers).every(provider => provider.format === 'binary')).toBe(true);
         expect(providers.ADS.url).toBe(REMOTE_SOURCES.ADS.singbox);
@@ -136,8 +137,22 @@ describe('Builtin template rule audit', () => {
         expect(adsRuleSet).toMatchObject({
             type: 'remote',
             format: 'binary',
-            url: 'https://raw.githubusercontent.com/SagerNet/sing-geosite/rule-set/geosite-category-ads-all.srs',
-            download_detour: 'DIRECT'
+            url: REMOTE_SOURCES.ADS.singbox,
+            download_detour: DNS_PROXY_GROUP
         });
+    });
+
+    it('applies the local-only listener and split-DNS baseline to template outputs', () => {
+        const model = getOptimizedTemplateModel('clash_misub_media_ai');
+        const clash = yaml.load(renderClashFromTemplateModel(model));
+        const singbox = JSON.parse(renderSingboxFromTemplateModel(model));
+
+        expect(clash['allow-lan']).toBe(false);
+        expect(clash['bind-address']).toBe('127.0.0.1');
+        expect(clash['external-controller']).toBe('127.0.0.1:9090');
+        expect(clash.dns['respect-rules']).toBe(true);
+        expect(singbox.inbounds[0]).toMatchObject({ type: 'tun', auto_route: true, strict_route: true });
+        expect(singbox.dns.final).toBe('dns-foreign-1');
+        expect(singbox.outbounds.find(outbound => outbound.tag === '🌐 DNS 出口')?.outbounds).not.toContain('DIRECT');
     });
 });

--- a/tests/unit/node-utils.test.js
+++ b/tests/unit/node-utils.test.js
@@ -50,6 +50,15 @@ describe('node-utils', () => {
         expect(proxies[0].name).toContain('台湾 1');
     });
 
+    it('urlsToClashProxies 应过滤本机回环出口', () => {
+        const proxies = urlsToClashProxies([
+            'trojan://fake@127.0.0.1:443#伪节点',
+            'trojan://real@example.com:443#真实节点'
+        ]);
+
+        expect(proxies.map(proxy => proxy.server)).toEqual(['example.com']);
+    });
+
     it('TUIC 节点密码包含 URL 保留字符时应保持可回环解析', () => {
         const proxy = {
             name: 'TUIC Special',

--- a/tests/unit/safe-dns.test.js
+++ b/tests/unit/safe-dns.test.js
@@ -28,6 +28,11 @@ describe('shared split DNS policy', () => {
         expect(dns.nameserver.every(server => server.endsWith(`#${DNS_PROXY_GROUP}`))).toBe(true);
         expect(singbox.servers.some(server => server.type === 'https' && server.detour === DNS_PROXY_GROUP)).toBe(true);
         expect(singbox.final).toBe('dns-foreign-1');
+        expect(singbox.rules[0]).toEqual({
+            rule_set: ['geosite-cn'],
+            action: 'route',
+            server: 'dns-cn-1'
+        });
     });
 
     it('downgrades encrypted KV foreign resolvers to plain UDP in clean mode', () => {

--- a/tests/unit/safe-dns.test.js
+++ b/tests/unit/safe-dns.test.js
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import {
+    DNS_PROXY_GROUP,
+    buildSingboxDnsConfig,
+    resolveDnsPolicy,
+    resolveSafeDnsConfig
+} from '../../functions/modules/subscription/safe-dns.js';
+
+describe('shared split DNS policy', () => {
+    it('routes domestic names directly and foreign names through the proxy group in clean mode', () => {
+        const dns = resolveSafeDnsConfig('');
+
+        expect(dns['respect-rules']).toBe(true);
+        expect(dns['nameserver-policy']['geosite:cn']).toEqual(['223.5.5.5', '119.29.29.29']);
+        expect(dns.nameserver).toEqual([
+            `udp://8.8.8.8:53#${DNS_PROXY_GROUP}`,
+            `udp://1.1.1.1:53#${DNS_PROXY_GROUP}`
+        ]);
+        expect(dns.fallback).toEqual([]);
+        expect(dns['proxy-server-nameserver']).toEqual(['223.5.5.5', '119.29.29.29']);
+    });
+
+    it('uses encrypted foreign resolvers only in polluted mode', () => {
+        const dns = resolveSafeDnsConfig('', { mode: 'polluted' });
+        const singbox = buildSingboxDnsConfig('', { mode: 'polluted' });
+
+        expect(dns.nameserver.every(server => server.startsWith('https://'))).toBe(true);
+        expect(dns.nameserver.every(server => server.endsWith(`#${DNS_PROXY_GROUP}`))).toBe(true);
+        expect(singbox.servers.some(server => server.type === 'https' && server.detour === DNS_PROXY_GROUP)).toBe(true);
+        expect(singbox.final).toBe('dns-foreign-1');
+    });
+
+    it('rejects unsafe resolver overrides and keeps the safe policy', () => {
+        const policy = resolveDnsPolicy({
+            mode: 'polluted',
+            domestic: ['127.0.0.1'],
+            foreign: ['udp://0.0.0.0:53#DIRECT'],
+            polluted: ['https://8.8.8.8/dns-query']
+        });
+
+        expect(policy.domestic).toEqual(['223.5.5.5', '119.29.29.29']);
+        expect(policy.foreign).toEqual(['udp://8.8.8.8:53', 'udp://1.1.1.1:53']);
+        expect(policy.polluted).toEqual(['https://8.8.8.8/dns-query']);
+    });
+});

--- a/tests/unit/safe-dns.test.js
+++ b/tests/unit/safe-dns.test.js
@@ -30,6 +30,13 @@ describe('shared split DNS policy', () => {
         expect(singbox.final).toBe('dns-foreign-1');
     });
 
+    it('downgrades encrypted KV foreign resolvers to plain UDP in clean mode', () => {
+        const dns = resolveSafeDnsConfig({ nameserver: ['https://dns.google/dns-query'] });
+
+        expect(dns.nameserver).toEqual([`udp://dns.google:53#${DNS_PROXY_GROUP}`]);
+        expect(dns.fallback).toEqual([]);
+    });
+
     it('rejects unsafe resolver overrides and keeps the safe policy', () => {
         const policy = resolveDnsPolicy({
             mode: 'polluted',

--- a/tests/unit/subscription-protective-cache.test.js
+++ b/tests/unit/subscription-protective-cache.test.js
@@ -32,6 +32,8 @@ describe('subscription protective node cache', () => {
     it('识别真实代理节点，排除系统伪节点', () => {
         expect(isRealProxyNode('trojan://pass@example.com:443#HK')).toBe(true);
         expect(isRealProxyNode('vmess://eyJhZGQiOiJleGFtcGxlLmNvbSJ9')).toBe(true);
+        expect(isRealProxyNode('trojan://00000000-0000-0000-0000-000000000000@127.0.0.1:443#伪节点')).toBe(false);
+        expect(isRealProxyNode('vless://00000000-0000-0000-0000-000000000000@[::1]:443#伪节点')).toBe(false);
         expect(isRealProxyNode('127.0.0.1:8080#剩余流量')).toBe(false);
         expect(isRealProxyNode('到期时间：2099-01-01')).toBe(false);
         expect(isRealProxyNode('')).toBe(false);

--- a/tests/unit/subscription-smoke.test.js
+++ b/tests/unit/subscription-smoke.test.js
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import yaml from 'js-yaml';
+import { generateBuiltinClashConfig } from '../../functions/modules/subscription/builtin-clash-generator.js';
+import { generateBuiltinSingboxConfig } from '../../functions/modules/subscription/builtin-singbox-generator.js';
+import { validateClashConfig, validateSingboxConfig } from '../../scripts/smoke-subscription.mjs';
+
+const NODE = 'trojan://password@1.2.3.4:443#SmokeNode';
+
+describe('Clash/sing-box subscription smoke invariants', () => {
+    for (const mode of ['clean', 'polluted']) {
+        it(`accepts ${mode} built-in Clash and sing-box output`, () => {
+            const options = mode === 'polluted' ? { dnsMode: 'polluted' } : {};
+            const clash = yaml.load(generateBuiltinClashConfig(NODE, options));
+            const singbox = JSON.parse(generateBuiltinSingboxConfig(NODE, options));
+
+            expect(() => validateClashConfig(clash, mode)).not.toThrow();
+            expect(() => validateSingboxConfig(singbox, mode)).not.toThrow();
+        });
+    }
+});

--- a/tests/unit/template-pipeline.test.js
+++ b/tests/unit/template-pipeline.test.js
@@ -3,6 +3,7 @@ import yaml from 'js-yaml';
 import { parseIniTemplate } from '../../functions/modules/subscription/template-parsers/ini-template-parser.js';
 import { renderClashFromIniTemplate, renderLoonFromIniTemplate, renderQuanxFromIniTemplate, renderSingboxFromIniTemplate, renderSurgeFromIniTemplate } from '../../functions/modules/subscription/template-pipeline.js';
 import { getBuiltinTemplate } from '../../functions/modules/subscription/builtin-template-registry.js';
+import { PINNED_RULE_REVISIONS } from '../../functions/modules/subscription/builtin-rules-provider.js';
 
 const SS2022_V2RAY_PLUGIN_NODE = 'ss://MjAyMi1ibGFrZTMtYWVzLTI1Ni1nY206TldSak1UVmxNVFZtTWpnMU5HRTVaRGsxT1dJd1pUUm1ZbVJrTnpkaU5qTT0@cf.090227.xyz:8080?plugin=v2ray-plugin%3Bmode%3Dwebsocket%3Bhost%3Dss.2227tsj.workers.dev%3Bpath%3D%2F%3Fenc%5C%3D2022-blake3-aes-256-gcm%3Bmux%3D0#2022-blake3-aes-256-gcm';
 
@@ -108,6 +109,27 @@ MATCH,节点选择
         const autoSelectGroup = parsed['proxy-groups'].find(group => group.name === '自动选择');
         expect(autoSelectGroup.proxies).toEqual(['HK-01', 'JP-01']);
         expect(autoSelectGroup.proxies).not.toContain('DIRECT');
+    });
+
+    it('adds fail-closed AI service groups without changing a normal Main group', () => {
+        const rendered = renderClashFromIniTemplate(`
+[Proxy Group]
+Main = select, HK-01, DIRECT
+
+[Rule]
+MATCH,Main
+        `, {
+            proxies: [
+                { name: 'HK-01', type: 'trojan', server: '1.1.1.1', port: 443, password: 'pass' }
+            ]
+        });
+
+        const parsed = yaml.load(rendered);
+        const aiGroups = parsed['proxy-groups'].filter(group => String(group.name).startsWith('🤖'));
+        expect(aiGroups.length).toBeGreaterThan(3);
+        expect(aiGroups.every(group => !group.proxies.includes('DIRECT'))).toBe(true);
+        expect(parsed['proxy-groups'].find(group => group.name === 'Main').proxies).toContain('DIRECT');
+        expect(parsed.rules).toContain('DOMAIN-SUFFIX,anthropic.com,🤖 Claude');
     });
 
     it('should keep Clash template relay-like groups as plain select without dialer-proxy', () => {
@@ -226,7 +248,7 @@ MATCH,节点选择
         expect(loonRendered).toContain('grpc-service-name=edge');
         expect(loonRendered).toContain('reality=true');
         expect(loonRendered).toContain('WG-01 = wireguard');
-        expect(loonRendered).toContain('RULE-SET,https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Ruleset/OpenAi.list,🤖 AI 服务');
+        expect(loonRendered).toContain(`https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/${PINNED_RULE_REVISIONS.ACL4SSR}/Clash/Ruleset/OpenAi.list, policy=🤖 AI 服务, enabled=true`);
         expect(loonRendered).toContain('🚀 节点选择 = select');
         expect(quanxRendered).toContain('[server_local]');
         expect(quanxRendered).toContain('[policy]');
@@ -234,11 +256,11 @@ MATCH,节点选择
         expect(quanxRendered).toContain('[filter_local]');
         expect(quanxRendered).toContain('vmess=1.2.3.6:443, method=none, password=uuid-5678, obfs=wss, obfs-uri=/ws, obfs-host=example.com, tag=🇺🇸 US-01');
         expect(quanxRendered).not.toContain('vmess=1.2.3.6:443, method=none, password=uuid-5678, obfs=ws,');
-        expect(quanxRendered).toContain('filter_remote, https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Ruleset/OpenAi.list, tag=🤖 AI 服务, force-policy=🤖 AI 服务, update-interval=86400, enabled=true');
+        expect(quanxRendered).toContain(`filter_remote, https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/${PINNED_RULE_REVISIONS.ACL4SSR}/Clash/Ruleset/OpenAi.list, tag=🤖 AI 服务, force-policy=🤖 AI 服务, update-interval=86400, enabled=true`);
         expect(quanxRendered).toContain('static=🚀 节点选择');
         expect(surgeRendered).not.toContain('SG-01 = vless');
         expect(surgeRendered).toContain('WG-01 = wireguard');
-        expect(surgeRendered).toContain('RULE-SET,https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Ruleset/OpenAi.list,🤖 AI 服务');
+        expect(surgeRendered).toContain(`RULE-SET,https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/${PINNED_RULE_REVISIONS.ACL4SSR}/Clash/Ruleset/OpenAi.list,🤖 AI 服务`);
         expect(surgeRendered).toContain('🚀 节点选择 = select');
     });
 
@@ -447,8 +469,8 @@ custom_proxy_group=🚀 节点选择\`select\`[]DIRECT\`.*
         const parsed = yaml.load(rendered);
         const providerUrls = Object.values(parsed['rule-providers'] || {}).map(provider => provider.url);
 
-        expect(providerUrls).toContain('https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Providers/Ruleset/Telegram.yaml');
-        expect(providerUrls).toContain('https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Providers/ProxyGFWlist.yaml');
+        expect(providerUrls).toContain(`https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/${PINNED_RULE_REVISIONS.ACL4SSR}/Clash/Providers/Ruleset/Telegram.yaml`);
+        expect(providerUrls).toContain(`https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/${PINNED_RULE_REVISIONS.ACL4SSR}/Clash/Providers/ProxyGFWlist.yaml`);
     });
 
     it('keeps ACL4SSR root list rules inline when provider YAML files are missing', () => {
@@ -469,8 +491,8 @@ custom_proxy_group=🚀 节点选择\`select\`[]DIRECT\`.*
         const localAreaProvider = Object.values(parsed['rule-providers'] || {}).find(provider => provider.url.includes('/Clash/LocalAreaNetwork.list'));
         const banAdProvider = Object.values(parsed['rule-providers'] || {}).find(provider => provider.url.includes('/Clash/BanAD.list'));
 
-        expect(providerUrls).not.toContain('https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Providers/Ruleset/LocalAreaNetwork.yaml');
-        expect(providerUrls).not.toContain('https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Providers/Ruleset/BanAD.yaml');
+        expect(providerUrls).not.toContain(`https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/${PINNED_RULE_REVISIONS.ACL4SSR}/Clash/Providers/Ruleset/LocalAreaNetwork.yaml`);
+        expect(providerUrls).not.toContain(`https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/${PINNED_RULE_REVISIONS.ACL4SSR}/Clash/Providers/Ruleset/BanAD.yaml`);
         expect(localAreaProvider).toMatchObject({ behavior: 'classical', format: 'text', path: './ruleset/localareanetwork_0.list' });
         expect(banAdProvider).toMatchObject({ behavior: 'classical', format: 'text', path: './ruleset/banad_1.list' });
         expect(parsed.rules).toContain('RULE-SET,localareanetwork_0,🎯 全球直连');
@@ -494,10 +516,10 @@ custom_proxy_group=🚀 节点选择\`select\`[]DIRECT\`.*
         const providers = Object.values(parsed['rule-providers'] || {});
         const providerUrls = providers.map(provider => provider.url);
 
-        expect(providerUrls).toContain('https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Providers/ChinaCompanyIp.yaml');
-        expect(providerUrls).toContain('https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Providers/ChinaIp.yaml');
-        expect(providerUrls).toContain('https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Providers/ChinaIpV6.yaml');
-        expect(providerUrls).not.toContain('https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/ChinaCompanyIp.list');
+        expect(providerUrls).toContain(`https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/${PINNED_RULE_REVISIONS.ACL4SSR}/Clash/Providers/ChinaCompanyIp.yaml`);
+        expect(providerUrls).toContain(`https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/${PINNED_RULE_REVISIONS.ACL4SSR}/Clash/Providers/ChinaIp.yaml`);
+        expect(providerUrls).toContain(`https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/${PINNED_RULE_REVISIONS.ACL4SSR}/Clash/Providers/ChinaIpV6.yaml`);
+        expect(providerUrls).not.toContain(`https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/${PINNED_RULE_REVISIONS.ACL4SSR}/Clash/ChinaCompanyIp.list`);
 
         for (const provider of providers) {
             expect(provider).toMatchObject({ behavior: 'ipcidr' });
@@ -522,7 +544,7 @@ custom_proxy_group=📥 下载服务\`select\`[]🚀 节点选择\`[]DIRECT
         const providers = parsed['rule-providers'] || {};
         const downloadProvider = Object.values(providers).find(provider => provider.url.includes('/Clash/Download.list'));
 
-        expect(Object.values(providers).map(provider => provider.url)).not.toContain('https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/Providers/Download.yaml');
+        expect(Object.values(providers).map(provider => provider.url)).not.toContain(`https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/${PINNED_RULE_REVISIONS.ACL4SSR}/Clash/Providers/Download.yaml`);
         expect(downloadProvider).toMatchObject({ behavior: 'classical', format: 'text', path: './ruleset/download_0.list' });
         expect(parsed.rules).toContain('RULE-SET,download_0,📥 下载服务');
     });

--- a/tests/unit/template-pipeline.test.js
+++ b/tests/unit/template-pipeline.test.js
@@ -27,6 +27,12 @@ MATCH,节点选择
         expect(parsed.dns.servers).toEqual(expect.arrayContaining([
             expect.objectContaining({ type: 'udp', server: '223.5.5.5', server_port: 53 })
         ]));
+        expect(parsed.dns.rules).toEqual(expect.arrayContaining([
+            expect.objectContaining({ rule_set: ['geosite-cn'], action: 'route', server: 'dns-cn-1' })
+        ]));
+        expect(parsed.route.rule_set).toEqual(expect.arrayContaining([
+            expect.objectContaining({ tag: 'geosite-cn', type: 'remote', format: 'binary' })
+        ]));
         expect(parsed.dns.servers.every(server => !Object.hasOwn(server, 'address'))).toBe(true);
         expect(trojan).toBeDefined();
     });

--- a/wrangler-cf-pages.toml
+++ b/wrangler-cf-pages.toml
@@ -1,71 +1,7 @@
 name = "misub"
-type = "javascript"
-main = "src/index.js"
-compatibility_date = "2024-04-01"
-
-# 🚀 Cloudflare Pages 部署配置
-# 这个配置用于部署到 Cloudflare Pages
-# 注意：Cloudflare Pages 会自动处理路由和绑定
-
-# Pages 特定配置
-build = { command = "npm run build", cwd = "./" }
-main = "functions"
-
-# 不要设置 account_id 或 zone_id
-# Cloudflare Pages 会自动处理这些
-
-# 兼容性设置
+pages_build_output_dir = "./dist"
 compatibility_date = "2024-04-01"
 compatibility_flags = ["nodejs_compat"]
 
-# 环境变量（通过 Cloudflare Pages UI 设置）
-# 不要在这里直接设置敏感信息
-[env.production]
-name = "misub-production"
-vars = {
-  ENVIRONMENT = "production",
-  LOG_LEVEL = "info",
-
-  # Cron 配置（通过环境变量，无需修改代码）
-  ENABLE_CRON = "true",                    # 是否启用Cron功能
-  CRON_TYPE = "hourly-subscription-sync",  # Cron任务类型
-  CRON_MAX_SYNC_COUNT = "50",              # 每次最多同步多少个订阅
-  CRON_SYNC_TIMEOUT = "30000",             # 单个订阅同步超时（毫秒）
-  CRON_ENABLE_PARALLEL = "true"            # 是否启用并行同步
-}
-
-# Cron Triggers 配置
-# 在 Functions 配置页面设置：
-# Settings -> Functions -> Cron Triggers
-# 或者通过 wrangler.json 的 triggers 部分
-# [triggers]
-# crons = [
-#   "0 * * * *",      # 每小时（推荐）
-#   "0 8 * * *",      # 每日8点
-#   "*/30 * * * *"    # 每30分钟
-# ]
-
-# Pages 部署配置
-[pages_build_caching]
-default_cache_on_cookie_presence_match = "session_id"
-
-# 不使用 KV 本地绑定，改用 Cloudflare UI
-# [[kv_namespaces]]
-# binding = "KV_STORAGE"
-# id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-
-# 不使用 D1 本地绑定，改用 Cloudflare UI
-# [[d1_databases]]
-# binding = "DB"
-# database_name = "misub"
-# database_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-
-# 📝 部署说明：
-# 1. 在 Cloudflare Pages 仪表板配置：
-#    - 连接 Git 仓库
-#    - 设置构建命令
-#    - 设置构建输出目录
-# 2. 环境变量通过 Pages 设置 -> 环境变量
-# 3. KV 和 D1 通过 Pages 设置 -> Functions -> KV 命名空间/D1 数据库
-# 4. Cron Triggers 通过 Pages 设置 -> Functions -> Cron Triggers
-# 5. 不需要在 wrangler.toml 中设置这些，以避免冲突
+# Pages 负责路由、KV 绑定、环境变量和 Cron 配置；这些运行时设置保留在
+# Cloudflare Pages 项目中，避免在仓库配置里覆盖生产环境值。


### PR DESCRIPTION
## Summary
- filter loopback and local pseudo-nodes before they reach generated client configurations
- replace loopback traffic/expiry placeholders with comments
- use safe Clash DNS defaults in built-in and template renderers
- simplify wrangler-cf-pages.toml to a valid Pages configuration

## Root cause
The previous shared node path accepted loopback Trojan placeholders as real proxy nodes, while Clash generators had unsafe DNS defaults (`ipv6: true` and rule-following DNS). That combination could break TUN clients and was not limited to one upstream provider.

## Validation
- `npm run build` passes
- targeted loopback/DNS regression tests pass
- public production subscription returns 200 with 75 proxies, IPv6 disabled, no `respect-rules`, no loopback proxies, dangling groups, or group cycles
- full suite retains the existing unrelated WireGuard/Loon failures