### PR TITLE
一些优化和Bug修复

### DIFF
--- a/docs/subscription-request-flow.md
+++ b/docs/subscription-request-flow.md
@@ -86,7 +86,7 @@ API 路径 `/api/*` 总是优先进入 `handleApiRequest(request, env)`，不会
 2. 按 `customId` 或 `id` 查找订阅组。
 3. 订阅组必须存在且 `enabled` 为真。
 4. 如果设置了 `expiresAt` 且已过期：
-   - 只返回一个过期提示伪节点。
+   - 只返回一个可解析的过期提示占位节点（节点名称为“您的订阅已到期”）。
    - 文件名仍使用订阅组名称。
 5. 未过期时：
    - 按订阅组中 `subscriptions` 的顺序选择 HTTP 订阅源。

--- a/functions/modules/api-handler.js
+++ b/functions/modules/api-handler.js
@@ -318,7 +318,7 @@ export async function handleMisubsSave(request, env) {
         if (finalMisubs && finalMisubs.length > 0) {
             try {
                 const notificationPromises = finalMisubs
-                    .filter(sub => sub && sub.url && sub.url.startsWith('http'))
+                    .filter(sub => sub?.enabled && sub.url && sub.url.startsWith('http'))
                     .map(sub => checkAndNotify(sub, settings, env).catch(notifyError => {
                         console.warn('[API] Notification failed for subscription:', sub?.name || sub?.url, notifyError);
                     }));

--- a/functions/modules/notifications.js
+++ b/functions/modules/notifications.js
@@ -60,7 +60,7 @@ async function persistSubscriptionsForCron(storageAdapter, subscriptions) {
  * 检查并发送订阅到期和流量预警通知
  */
 export async function checkAndNotify(sub, settings, env) {
-    if (!sub.userInfo) return;
+    if (!sub?.enabled || !sub.userInfo) return;
 
     const ONE_DAY_MS = 24 * 60 * 60 * 1000;
     const now = Date.now();

--- a/functions/modules/subscription/main-handler.js
+++ b/functions/modules/subscription/main-handler.js
@@ -519,7 +519,9 @@ export async function handleMisubRequest(context) {
     let subName = config.FileName;
     let isProfileExpired = false; // Moved declaration here
 
-    const DEFAULT_EXPIRED_NODE = '# MiSub: 您的订阅已失效';
+    // Use a valid, non-routable Shadowsocks URL so clients can display the
+    // expiration notice as a node instead of dropping a comment line.
+    const DEFAULT_EXPIRED_NODE = `ss://YWVzLTEyOC1nY206bWlzdWItZXhwaXJlZA==@192.0.2.1:1#${encodeURIComponent('您的订阅已到期')}`;
 
     let currentProfile = null;
 

--- a/functions/modules/subscription/main-handler.js
+++ b/functions/modules/subscription/main-handler.js
@@ -157,7 +157,7 @@ function buildUserInfoHeaderFromSubscriptions(context, subscriptions, profileExp
         : null;
 }
 
-export function formatNotificationExpireTime(profileExpiresAt, mergedExpireTimestamp = 0, now = Date.now()) {
+function resolveNotificationExpireDate(profileExpiresAt, mergedExpireTimestamp = 0) {
     let date = profileExpiresAt ? new Date(profileExpiresAt) : null;
     if (!date || Number.isNaN(date.getTime())) {
         const timestamp = Number(mergedExpireTimestamp);
@@ -166,13 +166,36 @@ export function formatNotificationExpireTime(profileExpiresAt, mergedExpireTimes
             : null;
     }
 
-    if (!date || Number.isNaN(date.getTime())) return '未设置';
-    if (date.getTime() <= now) return '已到期';
+    return !date || Number.isNaN(date.getTime()) ? null : date;
+}
+
+export function formatNotificationExpireTime(profileExpiresAt, mergedExpireTimestamp = 0) {
+    const date = resolveNotificationExpireDate(profileExpiresAt, mergedExpireTimestamp);
+
+    if (!date) return '未设置';
 
     return date.toLocaleString('zh-CN', {
         timeZone: 'Asia/Shanghai',
         hour12: false
     });
+}
+
+export function formatNotificationExpireStatus(
+    profileExpiresAt,
+    mergedExpireTimestamp = 0,
+    now = Date.now(),
+    thresholdDays = 3
+) {
+    const date = resolveNotificationExpireDate(profileExpiresAt, mergedExpireTimestamp);
+    if (!date) return '正常';
+    if (date.getTime() <= now) return '已到期';
+
+    const threshold = Number.isFinite(Number(thresholdDays))
+        ? Math.max(0, Number(thresholdDays))
+        : 3;
+    const remainingMs = date.getTime() - now;
+    if (remainingMs <= threshold * 24 * 60 * 60 * 1000) return '即将到期';
+    return '正常';
 }
 
 function formatSubscriptionExpireTime(expireTimestamp) {
@@ -845,7 +868,14 @@ export async function handleMisubRequest(context) {
 
     const domain = url.hostname;
     const mergedExpireTimestamp = mergeSubscriptionUserInfo(context, targetMisubs).expire;
-    const profileExpireText = `<b>到期时间:</b> <code>${tgEscape(formatNotificationExpireTime(currentProfile?.expiresAt, mergedExpireTimestamp))}</code>`;
+    const expireTime = formatNotificationExpireTime(currentProfile?.expiresAt, mergedExpireTimestamp);
+    const expireStatus = formatNotificationExpireStatus(
+        currentProfile?.expiresAt,
+        mergedExpireTimestamp,
+        Date.now(),
+        config.NotifyThresholdDays
+    );
+    const profileExpireText = `<b>状态:</b> <code>${tgEscape(expireStatus)}</code>\n<b>到期时间:</b> <code>${tgEscape(expireTime)}</code>`;
     const nodeCount = isProfileExpired ? 0 : countSubscriptionNodes(combinedNodeList, prependedContentForSubconverter);
     const nodeCountText = `<b>节点数:</b> <code>${nodeCount}</code>`;
 
@@ -945,7 +975,7 @@ export async function handleMisubRequest(context) {
                     config,
                     '🛰️ <b>订阅被访问</b> (第三方转换)',
                     clientIp,
-                    `<b>域名:</b> <code>${tgEscape(domain)}</code>\n<b>请求格式:</b> <code>${tgEscape(targetFormat)}</code>\n<b>客户端:</b> <code>${tgEscape(userAgentHeader)}</code>\n${nodeCountText}\n<b>订阅组:</b> <code>${tgEscape(subName)}</code>\n${profileExpireText}`
+                    `<b>域名:</b> <code>${tgEscape(domain)}</code>\n<b>请求格式:</b> <code>${tgEscape(targetFormat)}</code>\n<b>客户端:</b> <code>${tgEscape(userAgentHeader)}</code>\n<b>订阅组:</b> <code>${tgEscape(subName)}</code>\n${nodeCountText}\n${profileExpireText}`
                 )
             );
         }
@@ -986,7 +1016,7 @@ export async function handleMisubRequest(context) {
                     config,
                     '🛰️ <b>订阅被访问</b>',
                     clientIp,
-                    `<b>域名:</b> <code>${tgEscape(domain)}</code>\n<b>请求格式:</b> <code>${tgEscape(targetFormat)}</code>\n<b>客户端:</b> <code>${tgEscape(userAgentHeader)}</code>\n${nodeCountText}\n<b>订阅组:</b> <code>${tgEscape(subName)}</code>\n${profileExpireText}`
+                    `<b>域名:</b> <code>${tgEscape(domain)}</code>\n<b>请求格式:</b> <code>${tgEscape(targetFormat)}</code>\n<b>客户端:</b> <code>${tgEscape(userAgentHeader)}</code>\n<b>订阅组:</b> <code>${tgEscape(subName)}</code>\n${nodeCountText}\n${profileExpireText}`
                 )
             );
 
@@ -1099,7 +1129,7 @@ export async function handleMisubRequest(context) {
                         config,
                         '🛰️ <b>订阅被访问</b> (内置转换)',
                         clientIp,
-                        `<b>域名:</b> <code>${tgEscape(domain)}</code>\n<b>请求格式:</b> <code>${tgEscape(targetFormat)}</code>\n<b>客户端:</b> <code>${tgEscape(userAgentHeader)}</code>\n${nodeCountText}\n<b>订阅组:</b> <code>${tgEscape(subName)}</code>\n${profileExpireText}`
+                        `<b>域名:</b> <code>${tgEscape(domain)}</code>\n<b>请求格式:</b> <code>${tgEscape(targetFormat)}</code>\n<b>客户端:</b> <code>${tgEscape(userAgentHeader)}</code>\n<b>订阅组:</b> <code>${tgEscape(subName)}</code>\n${nodeCountText}\n${profileExpireText}`
                     )
                 );
 

--- a/functions/modules/subscription/main-handler.js
+++ b/functions/modules/subscription/main-handler.js
@@ -521,7 +521,7 @@ export async function handleMisubRequest(context) {
 
     // Use a valid, non-routable Shadowsocks URL so clients can display the
     // expiration notice as a node instead of dropping a comment line.
-    const DEFAULT_EXPIRED_NODE = `ss://YWVzLTEyOC1nY206bWlzdWItZXhwaXJlZA==@192.0.2.1:1#${encodeURIComponent('您的订阅已到期')}`;
+    const DEFAULT_EXPIRED_NODE = `trojan://00000000-0000-0000-0000-000000000000@127.0.0.1:443#${encodeURIComponent('您的订阅已到期')}`;
 
     let currentProfile = null;
 
@@ -650,13 +650,13 @@ export async function handleMisubRequest(context) {
             }, 0);
             if (totalRemainingBytes > 0) {
                 const fakeNodeName = `流量剩余 ≫ ${formatBytes(totalRemainingBytes)}`;
-                virtualNodes.push(`# MiSub: ${fakeNodeName}`);
+                virtualNodes.push(`trojan://00000000-0000-0000-0000-000000000000@127.0.0.1:443#${encodeURIComponent(fakeNodeName)}`);
             }
 
             const expireText = formatSubscriptionExpireTime(expireTimestamp);
             if (expireText) {
                 const fakeNodeName = `到期时间 ≫ ${expireText}`;
-                virtualNodes.push(`# MiSub: ${fakeNodeName}`);
+                virtualNodes.push(`trojan://00000000-0000-0000-0000-000000000000@127.0.0.1:443#${encodeURIComponent(fakeNodeName)}`);
             }
 
             prependedContentForSubconverter = virtualNodes.join('\n');

--- a/functions/utils/node-transformer.js
+++ b/functions/utils/node-transformer.js
@@ -19,6 +19,7 @@ const DEFAULT_SORT_KEYS = [
 const REGION_CODE_TO_ZH = buildRegionCodeToZhMap();
 const REGION_ZH_TO_CODE = buildZhToCodeMap();
 const warnedRegexRules = new Set();
+const VIRTUAL_INFO_NODE_UUID = '00000000-0000-0000-0000-000000000000';
 
 function warnInvalidRegex(rule, error) {
     const key = `${rule.pattern || ''}|${rule.flags || ''}`;
@@ -268,6 +269,14 @@ function isUselessNode(record) {
     const name = String(record?.name || '').trim();
     const protocol = normalizeProtocol(record?.protocol);
     const server = String(record?.server || '').trim().toLowerCase();
+
+    const isVirtualInfoNode = protocol === 'trojan'
+        && server === '127.0.0.1'
+        && Number(record?.port) === 443
+        && String(record?.url || '').includes(`trojan://${VIRTUAL_INFO_NODE_UUID}@127.0.0.1:443#`)
+        && /(?:流量剩余|到期时间|您的订阅已到期)/.test(name);
+
+    if (isVirtualInfoNode) return false;
 
     if (!name) return true;
 

--- a/functions/utils/url-to-clash.js
+++ b/functions/utils/url-to-clash.js
@@ -5,6 +5,23 @@
 import { extractNodeMetadata } from '../modules/utils/metadata-extractor.js';
 import { isLocalProxyEndpoint } from './node-utils.js';
 
+const VIRTUAL_INFO_NODE_PASSWORD = '00000000-0000-0000-0000-000000000000';
+
+function isVirtualInfoProxy(proxy) {
+    if (!proxy || typeof proxy !== 'object') return false;
+
+    const type = String(proxy.type || '').toLowerCase();
+    const server = String(proxy.server || '').trim().toLowerCase();
+    const password = String(proxy.password || '').trim();
+    const name = String(proxy.name || '').trim();
+
+    return type === 'trojan'
+        && server === '127.0.0.1'
+        && Number(proxy.port) === 443
+        && password === VIRTUAL_INFO_NODE_PASSWORD
+        && /(?:流量剩余|到期时间)/.test(name);
+}
+
 /**
  * 解析 URL 查询参数
  * @param {string} url - 节点 URL
@@ -1494,7 +1511,7 @@ export function urlsToClashProxies(urls, options = {}) {
             
             return proxy;
         })
-        .filter(proxy => proxy !== null && !isLocalProxyEndpoint(proxy));
+        .filter(proxy => proxy !== null && (isVirtualInfoProxy(proxy) || !isLocalProxyEndpoint(proxy)));
 }
 
 /**

--- a/functions/utils/url-to-clash.js
+++ b/functions/utils/url-to-clash.js
@@ -19,7 +19,7 @@ function isVirtualInfoProxy(proxy) {
         && server === '127.0.0.1'
         && Number(proxy.port) === 443
         && password === VIRTUAL_INFO_NODE_PASSWORD
-        && /(?:流量剩余|到期时间)/.test(name);
+        && /(?:流量剩余|到期时间|您的订阅已到期)/.test(name);
 }
 
 /**

--- a/src/components/modals/ProfileModal.vue
+++ b/src/components/modals/ProfileModal.vue
@@ -109,11 +109,14 @@ const countryCodeMap = {
   'nz': ['🇳🇿', '新西兰', '紐西蘭'],
 };
 
-const filteredSubscriptions = computed(() => {
-  // Only consider items with valid http/https URLs as "Subscriptions"
-  const validSubs = props.allSubscriptions.filter(sub =>
-    sub.url && /^https?:\/\//.test(sub.url)
+const selectableSubscriptions = computed(() => {
+  return (props.allSubscriptions || []).filter(sub =>
+    sub.enabled && sub.url && /^https?:\/\//.test(sub.url)
   );
+});
+
+const filteredSubscriptions = computed(() => {
+  const validSubs = selectableSubscriptions.value;
 
   if (!subscriptionSearchTerm.value) {
     return validSubs;
@@ -324,7 +327,7 @@ const updateSelectedIds = (listName, newIds) => {
 
         <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
 
-          <SubscriptionSelector :subscriptions="allSubscriptions" :filtered-subscriptions="filteredSubscriptions"
+          <SubscriptionSelector :subscriptions="selectableSubscriptions" :filtered-subscriptions="filteredSubscriptions"
             :search-term="subscriptionSearchTerm" :selected-ids="localProfile.subscriptions || []"
             @update:search-term="subscriptionSearchTerm = $event"
             @update:selected-ids="updateSelectedIds('subscriptions', $event)"

--- a/src/components/modals/ProfileModal/SubscriptionSelector.vue
+++ b/src/components/modals/ProfileModal/SubscriptionSelector.vue
@@ -46,8 +46,21 @@ const orderedSelectedSubs = computed({
       .filter(Boolean);
   },
   set(newList) {
-    // 拖拽排序后更新 ID 顺序
-    emit('update:selectedIds', newList.map(s => s.id));
+    const availableIds = new Set(props.subscriptions.map(sub => sub.id));
+    const reorderedIds = newList.map(sub => sub.id);
+    let reorderedIndex = 0;
+
+    // 隐藏的禁用订阅仍保留原有关联，避免仅调整可见订阅顺序时被误删。
+    const mergedIds = props.selectedIds.map(id => {
+      if (!availableIds.has(id)) return id;
+      return reorderedIds[reorderedIndex++];
+    }).filter(Boolean);
+
+    if (reorderedIndex < reorderedIds.length) {
+      mergedIds.push(...reorderedIds.slice(reorderedIndex));
+    }
+
+    emit('update:selectedIds', mergedIds);
   }
 });
 </script>

--- a/tests/unit/main-handler-template-url.test.js
+++ b/tests/unit/main-handler-template-url.test.js
@@ -4,6 +4,7 @@ import {
     buildManagedConfigUrl,
     extractProxySectionFromBuiltin,
     formatNotificationExpireTime,
+    formatNotificationExpireStatus,
     resolveExternalTemplateConfigUrl,
     resolveTemplateSource,
     resolveTemplateUrl,
@@ -23,7 +24,19 @@ describe('Main handler template url', () => {
         expect(formatNotificationExpireTime('2031-01-02T03:04:05Z', mergedExpire, now)).toContain('2031');
         expect(formatNotificationExpireTime('', mergedExpire, now)).toContain('2030');
         expect(formatNotificationExpireTime('', 0, now)).toBe('未设置');
-        expect(formatNotificationExpireTime('', mergedExpire, Date.parse('2032-01-01T00:00:00Z'))).toBe('已到期');
+        expect(formatNotificationExpireTime('', mergedExpire, Date.parse('2032-01-01T00:00:00Z'))).toContain('2030');
+    });
+
+    it('formats expiration status independently from expiration time', () => {
+        const now = Date.parse('2029-01-01T00:00:00Z');
+        const soon = Math.floor(Date.parse('2029-01-04T00:00:00Z') / 1000);
+        const later = Math.floor(Date.parse('2029-02-01T00:00:00Z') / 1000);
+        const expired = Math.floor(Date.parse('2028-12-31T00:00:00Z') / 1000);
+
+        expect(formatNotificationExpireStatus('', 0, now)).toBe('正常');
+        expect(formatNotificationExpireStatus('', later, now, 3)).toBe('正常');
+        expect(formatNotificationExpireStatus('', soon, now, 3)).toBe('即将到期');
+        expect(formatNotificationExpireStatus('', expired, now, 3)).toBe('已到期');
     });
 
     it('should preserve subscription url while removing cache flags', () => {

--- a/tests/unit/notifications-disabled-subscription.test.js
+++ b/tests/unit/notifications-disabled-subscription.test.js
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { sendTgNotification } = vi.hoisted(() => ({
+  sendTgNotification: vi.fn()
+}));
+
+vi.mock('../../functions/services/notification-service.js', () => ({
+  sendTgNotification,
+  sendEnhancedTgNotification: vi.fn(),
+  tgEscape: value => String(value || '')
+}));
+
+describe('subscription notifications', () => {
+  beforeEach(() => {
+    sendTgNotification.mockReset();
+    sendTgNotification.mockResolvedValue(true);
+  });
+
+  it('does not send expiration reminders for disabled subscriptions', async () => {
+    const { checkAndNotify } = await import('../../functions/modules/notifications.js');
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const subscription = {
+      id: 'disabled-subscription',
+      name: 'Disabled Subscription',
+      enabled: false,
+      userInfo: {
+        upload: 0,
+        download: 0,
+        total: 100,
+        expire: nowSeconds + 24 * 60 * 60
+      }
+    };
+
+    await checkAndNotify(subscription, {
+      BotToken: 'test-token',
+      ChatID: 'test-chat',
+      NotifyThresholdDays: 7
+    }, {});
+
+    expect(sendTgNotification).not.toHaveBeenCalled();
+    expect(subscription.lastNotifiedExpire).toBeUndefined();
+  });
+
+  it('still sends expiration reminders for enabled subscriptions', async () => {
+    const { checkAndNotify } = await import('../../functions/modules/notifications.js');
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const subscription = {
+      id: 'enabled-subscription',
+      name: 'Enabled Subscription',
+      enabled: true,
+      userInfo: {
+        upload: 0,
+        download: 0,
+        total: 0,
+        expire: nowSeconds + 24 * 60 * 60
+      }
+    };
+
+    await checkAndNotify(subscription, {
+      BotToken: 'test-token',
+      ChatID: 'test-chat',
+      NotifyThresholdDays: 7
+    }, {});
+
+    expect(sendTgNotification).toHaveBeenCalledTimes(1);
+    expect(sendTgNotification.mock.calls[0][1]).toContain('订阅临期提醒');
+    expect(subscription.lastNotifiedExpire).toEqual(expect.any(Number));
+  });
+});

--- a/tests/unit/profile-subscription-selector.test.js
+++ b/tests/unit/profile-subscription-selector.test.js
@@ -1,0 +1,88 @@
+import { computed, defineComponent } from 'vue';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import ProfileModal from '../../src/components/modals/ProfileModal.vue';
+import SubscriptionSelector from '../../src/components/modals/ProfileModal/SubscriptionSelector.vue';
+import { createI18n } from '../../src/i18n/index.js';
+
+vi.mock('../../src/composables/useManualNodes.js', () => ({
+  useManualNodes: () => ({ manualNodeGroups: computed(() => []) })
+}));
+
+const ModalStub = defineComponent({
+  template: '<div><slot name="body" /></div>'
+});
+
+const DraggableStub = defineComponent({
+  name: 'Draggable',
+  props: {
+    modelValue: {
+      type: Array,
+      default: () => []
+    }
+  },
+  emits: ['update:modelValue'],
+  template: '<button data-test="reorder" @click="$emit(\'update:modelValue\', [...modelValue].reverse())">reorder</button>'
+});
+
+describe('profile subscription selection', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('only displays enabled airport subscriptions', () => {
+    const wrapper = mount(ProfileModal, {
+      props: {
+        show: true,
+        isNew: false,
+        profile: {
+          id: 'profile-1',
+          name: 'Profile',
+          subscriptions: ['enabled-sub', 'disabled-sub'],
+          manualNodes: []
+        },
+        allSubscriptions: [
+          { id: 'enabled-sub', name: 'Enabled Airport', url: 'https://enabled.example/sub', enabled: true },
+          { id: 'disabled-sub', name: 'Disabled Airport', url: 'https://disabled.example/sub', enabled: false }
+        ],
+        allManualNodes: []
+      },
+      global: {
+        plugins: [createI18n(), createPinia()],
+        stubs: {
+          Modal: ModalStub,
+          ProfileForm: true,
+          NodeSelector: true,
+          Draggable: true
+        }
+      }
+    });
+
+    expect(wrapper.text()).toContain('Enabled Airport');
+    expect(wrapper.text()).not.toContain('Disabled Airport');
+  });
+
+  it('preserves hidden disabled selections when visible subscriptions are reordered', async () => {
+    const wrapper = mount(SubscriptionSelector, {
+      props: {
+        subscriptions: [
+          { id: 'enabled-a', name: 'Airport A' },
+          { id: 'enabled-b', name: 'Airport B' }
+        ],
+        filteredSubscriptions: [],
+        selectedIds: ['enabled-a', 'disabled-hidden', 'enabled-b']
+      },
+      global: {
+        plugins: [createI18n()],
+        stubs: { Draggable: DraggableStub }
+      }
+    });
+
+    await wrapper.get('[data-test="reorder"]').trigger('click');
+
+    expect(wrapper.emitted('update:selectedIds')).toEqual([
+      [['enabled-b', 'disabled-hidden', 'enabled-a']]
+    ]);
+  });
+});


### PR DESCRIPTION
主要内容：
- 限制 Telegram 通知和数据保存逻辑，只处理已启用的订阅，并补充回归测试。
- 增强 Telegram 订阅访问通知，分别展示“正常 / 即将到期 / 已到期”状态和具体到期时间。
- 将订阅过期、流量剩余、到期时间提示改为客户端可解析的虚拟 Trojan 节点。
- 调整节点过滤逻辑，确保上述虚拟信息节点不会被当作无效本地节点移除。
- 编辑订阅组时只显示已启用的机场订阅；排序时仍保留已关联但被禁用的隐藏订阅。
- 补充通知过滤、到期状态及订阅选择器相关单元测试。