### PR TITLE
fix: upgrade js-yaml to 4.3.1, 3.15.1 (GHSA-5p4m-2wfm-xmqj)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.7.0",
       "dependencies": {
         "dompurify": "^3.2.6",
-        "js-yaml": "^4.1.0",
+        "js-yaml": "^4.3.1",
         "pinia": "^3.0.3",
         "qrcode": "^1.5.4",
         "vue": "^3.5.18",
@@ -2978,9 +2978,19 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "dompurify": "^3.2.6",
-    "js-yaml": "^4.1.0",
+    "js-yaml": "^4.3.1",
     "pinia": "^3.0.3",
     "qrcode": "^1.5.4",
     "vue": "^3.5.18",


### PR DESCRIPTION
## Summary
Upgrade js-yaml from 4.1.1 to 4.3.1, 3.15.1 to fix GHSA-5p4m-2wfm-xmqj.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | GHSA-5p4m-2wfm-xmqj |
| **Severity** | HIGH |
| **Scanner** | trivy |
| **Rule** | `GHSA-5p4m-2wfm-xmqj` |
| **File** | `package-lock.json` (dependency: `js-yaml`) |
| **Assessment** | Defensive hardening |

**Description**: JS-YAML: Quadratic CPU consumption in !!omap resolution (3.x and 4.x) — CVE-2026-59870 fix not backported

## Changes
- `package.json`
- `package-lock.json`

## Behavior Preservation
The change is scoped to 2 files on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
