### PR TITLE
修复 KV→D1 迁移漏搬业务数据导致的静默丢失

### DIFF
--- a/functions/modules/api-router.js
+++ b/functions/modules/api-router.js
@@ -99,10 +99,14 @@ export async function handleApiRequest(request, env, context = null) {
                     partialSuccess: migrationResult
                 }, 500);
             }
+            const migratedKeys = Object.entries(migrationResult.keys || {})
+                .filter(([, state]) => state === 'migrated')
+                .map(([key]) => key);
             return createJsonResponse({
                 success: true,
-                message: '数据已成功迁移到 D1 数据库',
-                details: migrationResult
+                message: `数据已成功迁移到 D1 数据库（搬运 ${migratedKeys.length} 个键）`,
+                details: migrationResult,
+                migratedKeys
             });
 
         } catch (error) {

--- a/functions/storage-adapter.js
+++ b/functions/storage-adapter.js
@@ -76,6 +76,20 @@ const D1_SCHEMA_STATEMENTS = [
     `CREATE INDEX IF NOT EXISTS idx_settings_updated_at ON settings(updated_at);`
 ];
 
+/**
+ * 以 settings 表为家的已知业务键。
+ * D1StorageAdapter._parseKey 靠它区分「预期的业务键」与「真正的未知 key」，
+ * 后者才告警。与 D1_MIGRATION_KEYS 保持一致。
+ */
+const D1_KNOWN_SETTINGS_KEYS = new Set([
+    'misub_dns_templates_v1',
+    'misub_rule_templates_v1',
+    'misub_clients_v1',
+    'misub_guestbook_v1',
+    'misub_settings_v1',
+    'misub_restore_snapshot_latest'
+]);
+
 async function ensureD1Schema(d1Db) {
     for (const statement of D1_SCHEMA_STATEMENTS) {
         await d1Db.prepare(statement).run();
@@ -538,6 +552,11 @@ class D1StorageAdapter {
             if (String(key).startsWith('misub_guestbook_v1')) {
                 return { table: 'settings', queryField: 'key', queryValue: key };
             }
+            // 这些业务键本来就以 settings 表为家（KV→D1 迁移会主动写它们），
+            // 不该走下面那条「未知格式」告警，否则真正的异常 key 会被噪声淹掉。
+            if (D1_KNOWN_SETTINGS_KEYS.has(String(key))) {
+                return { table: 'settings', queryField: 'key', queryValue: key };
+            }
             // 处理其他格式的 key，默认作为 settings 表的 key，但记录警告
             console.warn(`[D1 Storage] Unknown key format: ${key}, treating as settings key`);
             return { table: 'settings', queryField: 'key', queryValue: key };
@@ -763,6 +782,37 @@ export class StorageFactory {
 }
 
 /**
+ * KV → D1 需要搬运的业务键。
+ *
+ * 原实现只搬 subscriptions / profiles / settings 三个键，其余业务数据（DNS 模板、
+ * 规则模板、客户端、留言板……）留在 KV 里，迁移后按 storageType='d1' 读就全成空，
+ * 而接口仍返回「数据已成功迁移」。用户照官方引导解绑 KV 后就再也取不回。
+ *
+ * 刻意不搬的键，各有原因：
+ *   misub_webdav_backup_lock  —— 定时任务互斥锁，搬一个过期锁过去会挡住下次备份
+ *   misub_system_logs         —— 诊断日志，体积可能很大，非业务数据
+ *   misub_error_reports       —— 同上
+ *   misub_data_v1             —— 更早的遗留格式，由 api-router 的独立升级路径处理
+ */
+const D1_MIGRATION_KEYS = [
+    DATA_KEYS.SUBSCRIPTIONS,
+    DATA_KEYS.PROFILES,
+    'misub_dns_templates_v1',
+    'misub_rule_templates_v1',
+    'misub_clients_v1',
+    'misub_guestbook_v1',
+    'misub_settings_v1',
+    'misub_restore_snapshot_latest'
+];
+
+/** 需要按前缀枚举后逐条搬运的键 */
+const D1_MIGRATION_KEY_PREFIXES = [
+    DATA_KEYS.PROFILE_DOWNLOAD_COUNT_PREFIX
+];
+
+export { D1_MIGRATION_KEYS, D1_MIGRATION_KEY_PREFIXES };
+
+/**
  * 数据迁移工具
  */
 export class DataMigrator {
@@ -779,45 +829,65 @@ export class DataMigrator {
             const d1Adapter = new D1StorageAdapter(env.MISUB_DB);
             await ensureD1Schema(d1Adapter.db);
 
+            // keys: 逐键结果，'migrated' | 'empty' | 'failed'
             const results = {
                 subscriptions: false,
                 profiles: false,
                 settings: false,
+                keys: {},
                 errors: []
             };
 
-            // 迁移订阅数据
-            try {
-                const subscriptions = await kvAdapter.get(DATA_KEYS.SUBSCRIPTIONS);
-                if (subscriptions) {
-                    await d1Adapter.put(DATA_KEYS.SUBSCRIPTIONS, subscriptions);
-                    results.subscriptions = true;
+            const copyKey = async key => {
+                try {
+                    const value = await kvAdapter.get(key);
+                    if (value === null || value === undefined) {
+                        results.keys[key] = 'empty';
+                        return false;
+                    }
+                    await d1Adapter.put(key, value);
+                    results.keys[key] = 'migrated';
+                    return true;
+                } catch (error) {
+                    results.keys[key] = 'failed';
+                    results.errors.push(`${key} 迁移失败: ${error.message}`);
+                    return false;
                 }
-            } catch (error) {
-                results.errors.push(`订阅数据迁移失败: ${error.message}`);
+            };
+
+            for (const key of D1_MIGRATION_KEYS) {
+                const ok = await copyKey(key);
+                if (key === DATA_KEYS.SUBSCRIPTIONS) results.subscriptions = ok;
+                if (key === DATA_KEYS.PROFILES) results.profiles = ok;
             }
 
-            // 迁移配置文件
-            try {
-                const profiles = await kvAdapter.get(DATA_KEYS.PROFILES);
-                if (profiles) {
-                    await d1Adapter.put(DATA_KEYS.PROFILES, profiles);
-                    results.profiles = true;
+            // 前缀键：先枚举再逐条搬
+            for (const prefix of D1_MIGRATION_KEY_PREFIXES) {
+                try {
+                    const listed = await kvAdapter.list(prefix);
+                    for (const entry of listed) {
+                        const key = typeof entry === 'string' ? entry : entry?.name;
+                        if (key) await copyKey(key);
+                    }
+                } catch (error) {
+                    results.errors.push(`前缀 ${prefix} 枚举失败: ${error.message}`);
                 }
-            } catch (error) {
-                results.errors.push(`配置文件迁移失败: ${error.message}`);
             }
 
-            // 迁移设置
+            // settings 放在最后：storageType 要在其余数据都就位之后才翻成 d1，
+            // 否则中途失败会留下「已切 d1、数据还在 kv」的半迁移状态。
             try {
                 const settings = await kvAdapter.get(DATA_KEYS.SETTINGS);
                 if (settings) {
-                    // 更新存储类型为 D1
                     settings.storageType = STORAGE_TYPES.D1;
                     await d1Adapter.put(DATA_KEYS.SETTINGS, settings);
                     results.settings = true;
+                    results.keys[DATA_KEYS.SETTINGS] = 'migrated';
+                } else {
+                    results.keys[DATA_KEYS.SETTINGS] = 'empty';
                 }
             } catch (error) {
+                results.keys[DATA_KEYS.SETTINGS] = 'failed';
                 results.errors.push(`设置迁移失败: ${error.message}`);
             }
 

--- a/tests/unit/storage-migration-completeness.test.js
+++ b/tests/unit/storage-migration-completeness.test.js
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DataMigrator,
+  D1_MIGRATION_KEYS,
+  D1_MIGRATION_KEY_PREFIXES
+} from '../../functions/storage-adapter.js';
+
+/** 内存版 KV 命名空间，满足 isKVNamespace 的鸭子类型 */
+function makeKV(initial = {}) {
+  const store = new Map(Object.entries(initial).map(([k, v]) => [k, JSON.stringify(v)]));
+  return {
+    store,
+    get: async key => store.get(key) ?? null,
+    put: async (key, value) => { store.set(key, value); },
+    delete: async key => { store.delete(key); },
+    list: async ({ prefix } = {}) => ({
+      keys: [...store.keys()].filter(k => !prefix || k.startsWith(prefix)).map(name => ({ name }))
+    })
+  };
+}
+
+/** 内存版 D1：只实现 DataMigrator 用到的 prepare/bind/run/first */
+function makeD1() {
+  const tables = { subscriptions: new Map(), profiles: new Map(), settings: new Map() };
+  return {
+    tables,
+    prepare(sql) {
+      return {
+        bind(...args) {
+          return {
+            async run() {
+              if (/^\s*CREATE/i.test(sql)) return { success: true };
+              const table = sql.match(/INTO\s+(\w+)/i)?.[1];
+              if (table && tables[table]) tables[table].set(args[0], args[1]);
+              return { success: true };
+            },
+            async first() { return null; },
+            async all() { return { results: [] }; }
+          };
+        },
+        async run() { return { success: true }; }
+      };
+    }
+  };
+}
+
+// 用户在 KV 上实际会有的业务数据
+const KV_FIXTURE = {
+  misub_subscriptions_v1: [{ id: 's1', url: 'https://example.com/sub' }],
+  misub_profiles_v1: [{ id: 'p1', name: '组' }],
+  worker_settings_v1: { storageType: 'kv', mytoken: 't' },
+  misub_dns_templates_v1: [{ id: 'dns-1', kind: 'policy', policy: { mode: 'clean' } }],
+  misub_rule_templates_v1: [{ id: 'rule-1' }],
+  misub_clients_v1: [{ id: 'c1' }],
+  misub_guestbook_v1: [{ id: 'g1' }],
+  misub_settings_v1: { legacy: true },
+  misub_restore_snapshot_latest: { at: '2026-09-03' },
+  misub_profile_download_count_p1: 42,
+  misub_profile_download_count_p2: 7,
+  // 刻意不该被搬走的
+  misub_webdav_backup_lock: { lockedAt: 1 },
+  misub_system_logs: [{ msg: 'noise' }],
+  misub_error_reports: [{ msg: 'boom' }]
+};
+
+describe('KV → D1 迁移清单完整性', () => {
+  it('迁移清单覆盖全部业务键', () => {
+    expect(D1_MIGRATION_KEYS).toEqual(expect.arrayContaining([
+      'misub_subscriptions_v1',
+      'misub_profiles_v1',
+      'misub_dns_templates_v1',
+      'misub_rule_templates_v1',
+      'misub_clients_v1',
+      'misub_guestbook_v1',
+      'misub_settings_v1',
+      'misub_restore_snapshot_latest'
+    ]));
+    expect(D1_MIGRATION_KEY_PREFIXES).toContain('misub_profile_download_count_');
+  });
+
+  it('清单不含瞬时锁与诊断日志', () => {
+    for (const key of ['misub_webdav_backup_lock', 'misub_system_logs', 'misub_error_reports', 'misub_data_v1']) {
+      expect(D1_MIGRATION_KEYS).not.toContain(key);
+    }
+  });
+});
+
+describe('migrateKVToD1 实际搬运行为', () => {
+  const run = async (fixture = KV_FIXTURE) => {
+    const kv = makeKV(fixture);
+    const db = makeD1();
+    const result = await DataMigrator.migrateKVToD1({ MISUB_KV: kv, MISUB_DB: db });
+    return { kv, db, result };
+  };
+
+  it('DNS 模板会被搬到 D1——修复前正是这一条静默丢失', async () => {
+    const { db, result } = await run();
+    expect(result.keys['misub_dns_templates_v1']).toBe('migrated');
+    expect(db.tables.settings.has('misub_dns_templates_v1')).toBe(true);
+
+    const stored = JSON.parse(db.tables.settings.get('misub_dns_templates_v1'));
+    expect(stored[0]).toMatchObject({ id: 'dns-1', kind: 'policy' });
+  });
+
+  it('规则模板 / 客户端 / 留言板 / 恢复快照一并搬运', async () => {
+    const { result } = await run();
+    for (const key of ['misub_rule_templates_v1', 'misub_clients_v1', 'misub_guestbook_v1', 'misub_restore_snapshot_latest']) {
+      expect(result.keys[key]).toBe('migrated');
+    }
+  });
+
+  it('按前缀枚举搬运订阅组下载计数', async () => {
+    const { result } = await run();
+    expect(result.keys['misub_profile_download_count_p1']).toBe('migrated');
+    expect(result.keys['misub_profile_download_count_p2']).toBe('migrated');
+  });
+
+  it('瞬时锁与诊断日志不被搬运', async () => {
+    const { result, db } = await run();
+    for (const key of ['misub_webdav_backup_lock', 'misub_system_logs', 'misub_error_reports']) {
+      expect(result.keys[key]).toBeUndefined();
+      expect(db.tables.settings.has(key)).toBe(false);
+    }
+  });
+
+  it('settings 搬运时把 storageType 翻成 d1', async () => {
+    const { db, result } = await run();
+    expect(result.settings).toBe(true);
+    const settings = JSON.parse(db.tables.settings.get('main'));
+    expect(settings.storageType).toBe('d1');
+    expect(settings.mytoken).toBe('t');
+  });
+
+  it('保留 subscriptions / profiles 两个布尔位，兼容旧调用方', async () => {
+    const { result } = await run();
+    expect(result.subscriptions).toBe(true);
+    expect(result.profiles).toBe(true);
+  });
+
+  it('KV 里没有的键报 empty 而不是 failed', async () => {
+    const { result } = await run({ worker_settings_v1: { storageType: 'kv' } });
+    expect(result.keys['misub_dns_templates_v1']).toBe('empty');
+    expect(result.errors).toEqual([]);
+  });
+
+  it('缺少 KV 绑定时抛错，不静默成功', async () => {
+    await expect(DataMigrator.migrateKVToD1({ MISUB_DB: makeD1() }))
+      .rejects.toThrow('No KV binding found');
+  });
+});


### PR DESCRIPTION
migrateKVToD1 只搬 subscriptions / profiles / settings 三个键，其余业务数据 留在 KV。迁移后 storageType 变成 'd1'，读取切到 D1，这些数据就全成空——而接口仍返回「数据已成功迁移到 D1 数据库」。用户照官方引导解绑 KV 后再也取不回。

本地实测（先 kv 后迁移再重启）：
  修复前  迁移前 2 条 DNS 模板 → 迁移后 0 条
  修复后  迁移前 2 条 DNS 模板 → 迁移后 2 条

漏搬的键：DNS 模板、规则模板、客户端、留言板、misub_settings_v1、恢复快照，
以及按前缀枚举的订阅组下载计数 misub_profile_download_count_*。

- 搬运清单改成声明式 D1_MIGRATION_KEYS + D1_MIGRATION_KEY_PREFIXES， 后者先 list 枚举再逐条搬
- 刻意排除四个键并在注释里写明原因：webdav_backup_lock 是定时任务互斥锁， 搬过期锁会挡住下次备份；system_logs / error_reports 是诊断日志、体积可能 很大；misub_data_v1 是更早的遗留格式，由 api-router 的独立升级路径处理
- settings 改到最后搬。storageType 一翻成 'd1' 读取就切库，它必须等其余数据 就位；原实现放在中间，中途失败会留下「已切 d1、数据还在 kv」的半迁移状态
- 结果对象加 keys 逐键状态（migrated / empty / failed），保留原有三个布尔位 不破坏既有调用方；接口响应带上 migratedKeys 与键数量，让结果可核对
- _parseKey 的 Unknown key format 告警收窄：这些业务键本就以 settings 表为家， 每写一次打一行告警会把真正的异常 key 淹掉，改用 D1_KNOWN_SETTINGS_KEYS 白名单

缺陷来自上游，已核对 upstream/main（1008b7c）仍是原实现；上游当前唯一的 open PR 是 js-yaml 升级，未见相关 issue 或 PR。